### PR TITLE
Ensure docker publish on autopublish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_call:
 
 jobs:
   docker:
@@ -20,9 +21,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Extract version from tag
+      - name: Extract version
         id: meta
-        run: echo "version=${GITHUB_REF_TAG#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ -n "$GITHUB_REF_TAG" ] && echo "$GITHUB_REF_TAG" | grep -q '^v'; then
+            echo "version=${GITHUB_REF_TAG#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GITHUB_REF_TAG: ${{ github.ref_name }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,3 +60,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+
+  docker:
+    needs: publish
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit


### PR DESCRIPTION
The issue is that the tag is created by the publish workflow using GITHUB_TOKEN. Tags (and pushes) created by GITHUB_TOKEN do not trigger other workflows — this is a deliberate GitHub Actions limitation to prevent recursive workflow runs.

The publish workflow does git push --tags using the default secrets.GITHUB_TOKEN, so the v* tag it creates won't
trigger docker-publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Docker image publishing now integrated into the release workflow with improved version handling from git tags and package configuration fallback.
  * Enhanced CI/CD infrastructure enabling seamless Docker image deployment as part of the standard release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->