### PR TITLE
ci: add zizmor GitHub Actions security audit and fix all findings

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -9,21 +9,24 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   acceptance:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           always-auth: false
           node-version: 24.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,15 +21,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           always-auth: false
           node-version: ${{ matrix.node-version }}
@@ -52,6 +55,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: fastify/github-action-merge-dependabot@30c3f8f14a4f7b315ba38dbc1b793d27128fef82 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,15 @@ on:
         description: "Git ref (tag) to checkout"
         type: string
         required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: "Docker Hub username"
+        required: true
+      DOCKERHUB_TOKEN:
+        description: "Docker Hub access token"
+        required: true
+
+permissions: {}
 
 jobs:
   docker:
@@ -18,15 +27,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract version
         id: meta
@@ -40,20 +50,24 @@ jobs:
           GITHUB_REF_TAG: ${{ github.ref_name }}
 
       - name: Build image for testing
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           load: true
           tags: fauxqs-ci-test:latest
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
+      # Caching is disabled for this release workflow: a poisoned cache must
+      # not be able to influence the published image. setup-node v6 enables
+      # package-manager caching by default (package.json declares a
+      # packageManager field), so it is turned off explicitly here.
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Install test dependencies
         run: pnpm install --frozen-lockfile
@@ -64,13 +78,15 @@ jobs:
           FAUXQS_TEST_IMAGE: fauxqs-ci-test:latest
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # No build cache: the published image must not be assembled from
+      # layers that a less-trusted workflow run could have poisoned.
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -78,5 +94,3 @@ jobs:
           tags: |
             kibertoad/fauxqs:latest
             kibertoad/fauxqs:${{ steps.meta.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ensure-labels.yml
+++ b/.github/workflows/ensure-labels.yml
@@ -13,10 +13,14 @@ on:
       - labeled
       - unlabeled
 
+permissions: {}
+
 jobs:
   ensure_labels:
     name: Ensure PR has proper labeling
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # read the PR's labels
     steps:
       - name: Check one of required labels are set
         uses: docker://agilepathway/pull-request-label-checker:v1.6.65

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   typecheck-examples:
     runs-on: ubuntu-latest
@@ -20,14 +22,15 @@ jobs:
           - alternatives
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: 'pnpm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   publish:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
@@ -20,21 +22,28 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
+      # persist-credentials is intentionally kept enabled: the release steps
+      # below run `git push` for the version bump commit and tag. This workflow
+      # uploads no artifacts, so the artipacked credential-leak vector that
+      # zizmor warns about does not apply here.
+      - name: Checkout Repository # zizmor: ignore[artipacked]
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
+      # Caching is disabled: the npm release must not be built from a
+      # potentially poisoned cache. setup-node v6 enables package-manager
+      # caching by default, so it is turned off explicitly here.
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Configure Git
         run: |
@@ -61,10 +70,12 @@ jobs:
       - name: Bump version
         id: bump
         run: |
-          pnpm version ${{ steps.version.outputs.bump }} -m "chore: release v%s"
+          pnpm version "$VERSION_BUMP" -m "chore: release v%s"
           echo "tag=v$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
           git push
           git push --tags
+        env:
+          VERSION_BUMP: ${{ steps.version.outputs.bump }}
 
       - name: Publish to npm
         run: pnpm publish --provenance --access public --no-git-checks
@@ -74,4 +85,6 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       ref: ${{ needs.publish.outputs.tag }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout the repository
-      security-events: write # upload SARIF results to code scanning
 
     steps:
       - name: Checkout Repository
@@ -27,3 +26,9 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Emit findings as inline GitHub workflow annotations on the PR.
+          # This is mutually exclusive with advanced-security (SARIF upload to
+          # code scanning), which must therefore be turned off explicitly.
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+---
+name: zizmor
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: GitHub Actions security audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the repository
+      security-events: write # upload SARIF results to code scanning
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Summary

Adds the official [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action) as a new `zizmor` workflow that audits all GitHub Actions workflows on every PR and push to `main`, and fixes **every finding** zizmor reported against the existing workflows.

- **Blocks** — the zizmor step fails on any finding, so the check goes red and blocks the PR.
- **Annotates** — `annotations: true` emits findings as inline GitHub workflow annotations, which show on every PR run regardless of whether the PR touches a workflow file. (This is mutually exclusive with the SARIF/code-scanning output, so `advanced-security: false` is set explicitly.)

The audit currently passes with **zero findings** (verified locally with `zizmor` v1.25.2, online audits enabled).

## Findings fixed (37 total)

| Audit | Fix |
|---|---|
| `unpinned-uses` (21) | Every action is pinned to a full commit SHA, with the version kept in a trailing comment so Dependabot can still update them. |
| `excessive-permissions` (8) | Every workflow gets an explicit `permissions: {}`; jobs declare only the scopes they need (`automerge` → `pull-requests`/`contents: write`, `publish` → `contents`/`id-token: write`, `ensure_labels` → `pull-requests: read`). |
| `artipacked` (5) | `persist-credentials: false` added to checkouts that don't need the token. |
| `cache-poisoning` (1) | See note below. |
| `secrets-inherit` (1) | `secrets: inherit` replaced with an explicit `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` list, now declared on the `docker-publish` reusable workflow's `workflow_call.secrets`. |
| `template-injection` (1) | `steps.version.outputs.bump` is passed via `env:` instead of being expanded directly into the `run` block. |

## Caching removed from publishing workflows

Caches must not feed a release build — a cache poisoned by a less-trusted run could end up in the published artifact. `actions/setup-node@v6` **auto-enables** package-manager caching when `package.json` declares a `packageManager` field (it does: `pnpm@11.2.1`), so simply omitting `cache:` is not enough.

- `docker-publish.yml`: `package-manager-cache: false` on setup-node, and the `type=gha` Docker layer cache dropped from the published image build.
- `publish.yml`: `cache: 'pnpm'` replaced with `package-manager-cache: false`.

CI/test workflows (`ci`, `acceptance`, `examples`) keep their caches — they don't publish anything.

## One documented suppression

`publish.yml`'s checkout keeps persisted credentials (`# zizmor: ignore[artipacked]`): the release job runs `git push` for the version-bump commit and tag, so the token is genuinely required. The workflow uploads no artifacts, so the credential-leak vector `artipacked` warns about does not apply. The reasoning is documented inline above the step.

## Test plan

- [x] `zizmor .github/workflows/` (with online audits) → **no findings**
- [ ] Confirm the new `zizmor` check runs and annotates this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
