### PR TITLE
feat(sns): route undeliverable messages to subscription DLQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Supported subscription attributes:
 | `RawMessageDelivery` | `"true"` / `"false"` | Deliver the raw message body instead of the SNS envelope JSON. |
 | `FilterPolicy` | JSON string | SNS filter policy for message filtering (e.g., `"{\"color\": [\"blue\"]}"`) |
 | `FilterPolicyScope` | `"MessageAttributes"` / `"MessageBody"` | Whether the filter policy applies to message attributes or body. Defaults to `MessageAttributes`. |
-| `RedrivePolicy` | JSON string | Subscription-level dead-letter queue config. When the endpoint queue is missing at publish time, the message is routed to `deadLetterTargetArn` with SNS-style `ErrorCode` / `ErrorMessage` / `RequestID` attributes (matches AWS for `AWS.SimpleQueueService.NonExistentQueue`). |
+| `RedrivePolicy` | JSON string | Subscription-level dead-letter queue config. See [Subscription dead-letter queues](#subscription-dead-letter-queues) below. |
 | `DeliveryPolicy` | JSON string | Delivery retry policy (stored, not enforced). |
 | `SubscriptionRoleArn` | ARN string | IAM role ARN for delivery (stored, not enforced). |
 
@@ -1196,6 +1196,42 @@ Resources created via init config or programmatic API use the `defaultRegion` un
 | PutDataProtectionPolicy | No |
 
 Platform application, SMS, and phone number actions are not supported.
+
+#### Subscription dead-letter queues
+
+When an SQS subscription has a `RedrivePolicy` attribute set and its endpoint
+queue no longer exists at publish time, fauxqs reroutes the delivery to the
+DLQ rather than dropping the message — matching AWS and LocalStack behaviour.
+
+Scope: only the missing-endpoint case is modelled. Throttling, HTTP 5xx, and
+other delivery failures don't apply because fauxqs only delivers to SQS
+endpoints. Messages dropped by a `FilterPolicy` are not redriven.
+
+```ts
+await sns.send(
+  new SubscribeCommand({
+    TopicArn: topicArn,
+    Protocol: "sqs",
+    Endpoint: endpointQueueArn,
+    Attributes: {
+      RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlqArn }),
+    },
+  }),
+);
+
+// Later: endpoint queue is deleted, publish still succeeds, and the message
+// lands in the DLQ with these extra SQS message attributes:
+//   ErrorCode        = "AWS.SimpleQueueService.NonExistentQueue"
+//   ErrorMessage     = "The specified queue does not exist or you do not have access to it."
+//   RequestID        = <shared across all fan-out deliveries from this publish>
+//   AWS.SNS.MessageId = <original SNS MessageId>
+//   AWS.SNS.TopicARN  = <topic ARN>
+```
+
+The body is the normal SNS notification envelope, or the raw message body
+when `RawMessageDelivery=true`. `RedrivePolicy` is validated at write time:
+malformed JSON, non-object values, or a non-string `deadLetterTargetArn` are
+rejected at Subscribe / SetSubscriptionAttributes with `InvalidParameter`.
 
 ### S3
 

--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ Supported subscription attributes:
 | `RawMessageDelivery` | `"true"` / `"false"` | Deliver the raw message body instead of the SNS envelope JSON. |
 | `FilterPolicy` | JSON string | SNS filter policy for message filtering (e.g., `"{\"color\": [\"blue\"]}"`) |
 | `FilterPolicyScope` | `"MessageAttributes"` / `"MessageBody"` | Whether the filter policy applies to message attributes or body. Defaults to `MessageAttributes`. |
-| `RedrivePolicy` | JSON string | Subscription-level dead-letter queue config. |
+| `RedrivePolicy` | JSON string | Subscription-level dead-letter queue config. When the endpoint queue is missing at publish time, the message is routed to `deadLetterTargetArn` with SNS-style `ErrorCode` / `ErrorMessage` / `RequestID` attributes (matches AWS for `AWS.SimpleQueueService.NonExistentQueue`). |
 | `DeliveryPolicy` | JSON string | Delivery retry policy (stored, not enforced). |
 | `SubscriptionRoleArn` | ARN string | IAM role ARN for delivery (stored, not enforced). |
 

--- a/src/sns/actions/publish.ts
+++ b/src/sns/actions/publish.ts
@@ -9,6 +9,7 @@ import { SqsStore as SqsStoreClass } from "../../sqs/sqsStore.ts";
 import type { MessageAttributeValue } from "../../sqs/sqsTypes.ts";
 import { SNS_MAX_MESSAGE_SIZE_BYTES } from "../../common/types.ts";
 import { matchesFilterPolicy, matchesFilterPolicyOnBody } from "../filter.ts";
+import { parseSubscriptionRedrivePolicy } from "../subscriptionRedrivePolicy.ts";
 
 export function publish(
   params: Record<string, string>,
@@ -246,7 +247,7 @@ export function publishBatch(
 
 export function fanOutToSubscriptions(params: {
   topicArn: string;
-  topic: { subscriptionArns: string[] };
+  topic: { subscriptionArns: string[]; name: string };
   messageId: string;
   message: string;
   messageAttributes: Record<string, MessageAttributeValue>;
@@ -268,6 +269,12 @@ export function fanOutToSubscriptions(params: {
     snsStore,
     sqsStore,
   } = params;
+
+  // Shared per-publish RequestID — AWS uses one ID across all fan-out
+  // deliveries for a given publish. Generated lazily so we don't pay the
+  // randomUUID cost when no subscriber falls back to DLQ.
+  let cachedRequestId: string | undefined;
+  const getRequestId = (): string => (cachedRequestId ??= randomUUID());
 
   // Pre-compute envelope fields shared across subscriptions (only UnsubscribeURL varies)
   // Real AWS omits Subject and MessageAttributes when not provided
@@ -333,28 +340,35 @@ export function fanOutToSubscriptions(params: {
     // endpoints, etc.) aren't modelled here because fauxqs only delivers to
     // SQS endpoints, where the missing-queue case is the only real failure.
     let targetQueue = sqsStore.getQueueByArn(sub.endpoint);
+    let routedToDlq = false;
     if (!targetQueue) {
-      const dlqArn = getSubscriptionDlqArn(sub);
+      const dlqArn = resolveSubscriptionDlqArn(sub);
       if (!dlqArn) continue;
       const dlq = sqsStore.getQueueByArn(dlqArn);
       if (!dlq) continue;
       targetQueue = dlq;
+      routedToDlq = true;
       // SNS adds these on the DLQ message so consumers can see why delivery
-      // was redriven. Keys, DataTypes, and the ErrorCode/ErrorMessage strings
-      // match what real AWS surfaces for a missing SQS endpoint — see
+      // was redriven and which publish/topic it came from. Keys, DataTypes,
+      // and the ErrorCode/ErrorMessage strings match what real AWS surfaces
+      // for a missing SQS endpoint — see
       // https://repost.aws/knowledge-center/sns-sqs-subscriptions-notifications
       sqsAttributes = {
         ...sqsAttributes,
-        RequestID: { DataType: "String", StringValue: randomUUID() },
+        RequestID: { DataType: "String", StringValue: getRequestId() },
         ErrorCode: {
           DataType: "String",
           StringValue: "AWS.SimpleQueueService.NonExistentQueue",
         },
         ErrorMessage: {
           DataType: "String",
-          StringValue:
-            "The specified queue does not exist or you do not have access to it.",
+          StringValue: "The specified queue does not exist or you do not have access to it.",
         },
+        // Preserve correlation back to the original publish. Important
+        // especially for RawMessageDelivery, where the MessageId would
+        // otherwise be lost from the body.
+        "AWS.SNS.MessageId": { DataType: "String", StringValue: messageId },
+        "AWS.SNS.TopicARN": { DataType: "String", StringValue: topicArn },
       };
     }
 
@@ -374,21 +388,30 @@ export function fanOutToSubscriptions(params: {
     }
 
     targetQueue.enqueue(sqsMsg);
+
+    if (routedToDlq && snsStore.spy) {
+      snsStore.spy.addMessage({
+        service: "sns",
+        topicArn,
+        topicName: topic.name,
+        messageId,
+        body: sqsBody,
+        messageAttributes: sqsAttributes,
+        status: "dlq",
+        timestamp: Date.now(),
+      });
+    }
   }
 }
 
-function getSubscriptionDlqArn(sub: SnsSubscription): string | undefined {
+/**
+ * Resolve the DLQ ARN for a subscription's RedrivePolicy, using a memoised
+ * parse on the subscription. `parsedRedrivePolicy` is the cache:
+ * `undefined` = not parsed yet, `null` = absent/malformed, object = parsed.
+ */
+function resolveSubscriptionDlqArn(sub: SnsSubscription): string | undefined {
   if (sub.parsedRedrivePolicy === undefined) {
-    const raw = sub.attributes.RedrivePolicy;
-    if (!raw) {
-      sub.parsedRedrivePolicy = null;
-    } else {
-      try {
-        sub.parsedRedrivePolicy = JSON.parse(raw);
-      } catch {
-        sub.parsedRedrivePolicy = null;
-      }
-    }
+    sub.parsedRedrivePolicy = parseSubscriptionRedrivePolicy(sub.attributes.RedrivePolicy);
   }
   return sub.parsedRedrivePolicy?.deadLetterTargetArn;
 }

--- a/src/sns/actions/publish.ts
+++ b/src/sns/actions/publish.ts
@@ -3,6 +3,7 @@ import type { PublishResponse } from "@aws-sdk/client-sns";
 import { SnsError } from "../../common/errors.ts";
 import { snsSuccessResponse } from "../../common/xml.ts";
 import type { SnsStore } from "../snsStore.ts";
+import type { SnsSubscription } from "../snsTypes.ts";
 import type { SqsStore } from "../../sqs/sqsStore.ts";
 import { SqsStore as SqsStoreClass } from "../../sqs/sqsStore.ts";
 import type { MessageAttributeValue } from "../../sqs/sqsTypes.ts";
@@ -313,10 +314,6 @@ export function fanOutToSubscriptions(params: {
       }
     }
 
-    const sqsQueueArn = sub.endpoint;
-    const queue = sqsStore.getQueueByArn(sqsQueueArn);
-    if (!queue) continue;
-
     const isRaw = sub.attributes.RawMessageDelivery === "true";
 
     let sqsBody: string;
@@ -330,6 +327,37 @@ export function fanOutToSubscriptions(params: {
       sqsBody = JSON.stringify(envelopeBase);
     }
 
+    // Resolve the target queue. If the subscription endpoint is gone, fall
+    // back to the subscription's RedrivePolicy DLQ (matches AWS / LocalStack
+    // behaviour). Other delivery-failure modes (throttling, 5xx from HTTP
+    // endpoints, etc.) aren't modelled here because fauxqs only delivers to
+    // SQS endpoints, where the missing-queue case is the only real failure.
+    let targetQueue = sqsStore.getQueueByArn(sub.endpoint);
+    if (!targetQueue) {
+      const dlqArn = getSubscriptionDlqArn(sub);
+      if (!dlqArn) continue;
+      const dlq = sqsStore.getQueueByArn(dlqArn);
+      if (!dlq) continue;
+      targetQueue = dlq;
+      // SNS adds these on the DLQ message so consumers can see why delivery
+      // was redriven. Keys, DataTypes, and the ErrorCode/ErrorMessage strings
+      // match what real AWS surfaces for a missing SQS endpoint — see
+      // https://repost.aws/knowledge-center/sns-sqs-subscriptions-notifications
+      sqsAttributes = {
+        ...sqsAttributes,
+        RequestID: { DataType: "String", StringValue: randomUUID() },
+        ErrorCode: {
+          DataType: "String",
+          StringValue: "AWS.SimpleQueueService.NonExistentQueue",
+        },
+        ErrorMessage: {
+          DataType: "String",
+          StringValue:
+            "The specified queue does not exist or you do not have access to it.",
+        },
+      };
+    }
+
     const sqsMsg = SqsStoreClass.createMessage(
       sqsBody,
       sqsAttributes,
@@ -338,15 +366,31 @@ export function fanOutToSubscriptions(params: {
       messageDeduplicationId,
     );
 
-    if (queue.isFifo() && messageDeduplicationId) {
-      const dedupResult = queue.checkDeduplication(messageDeduplicationId);
+    if (targetQueue.isFifo() && messageDeduplicationId) {
+      const dedupResult = targetQueue.checkDeduplication(messageDeduplicationId);
       if (dedupResult.isDuplicate) continue;
-      sqsMsg.sequenceNumber = queue.nextSequenceNumber();
-      queue.recordDeduplication(messageDeduplicationId, sqsMsg.messageId);
+      sqsMsg.sequenceNumber = targetQueue.nextSequenceNumber();
+      targetQueue.recordDeduplication(messageDeduplicationId, sqsMsg.messageId);
     }
 
-    queue.enqueue(sqsMsg);
+    targetQueue.enqueue(sqsMsg);
   }
+}
+
+function getSubscriptionDlqArn(sub: SnsSubscription): string | undefined {
+  if (sub.parsedRedrivePolicy === undefined) {
+    const raw = sub.attributes.RedrivePolicy;
+    if (!raw) {
+      sub.parsedRedrivePolicy = null;
+    } else {
+      try {
+        sub.parsedRedrivePolicy = JSON.parse(raw);
+      } catch {
+        sub.parsedRedrivePolicy = null;
+      }
+    }
+  }
+  return sub.parsedRedrivePolicy?.deadLetterTargetArn;
 }
 
 function parseMessageAttributes(

--- a/src/sns/actions/setSubscriptionAttributes.ts
+++ b/src/sns/actions/setSubscriptionAttributes.ts
@@ -2,6 +2,8 @@ import { SnsError } from "../../common/errors.ts";
 import { snsSuccessResponse } from "../../common/xml.ts";
 import type { SnsStore } from "../snsStore.ts";
 import { validateFilterPolicyLimits } from "../filter.ts";
+import { validateSubscriptionRedrivePolicy } from "../subscriptionRedrivePolicy.ts";
+import { setSubscriptionAttribute } from "../snsStore.ts";
 
 const VALID_SUBSCRIPTION_ATTRIBUTES = new Set([
   "RawMessageDelivery",
@@ -39,14 +41,10 @@ export function setSubscriptionAttributes(
     if (attributeName === "FilterPolicy" && attributeValue) {
       validateFilterPolicyLimits(attributeValue);
     }
-    subscription.attributes[attributeName] = attributeValue;
-    // Invalidate cached parsed filter policy when relevant attributes change
-    if (attributeName === "FilterPolicy" || attributeName === "FilterPolicyScope") {
-      subscription.parsedFilterPolicy = undefined;
-    }
     if (attributeName === "RedrivePolicy") {
-      subscription.parsedRedrivePolicy = undefined;
+      validateSubscriptionRedrivePolicy(attributeValue);
     }
+    setSubscriptionAttribute(subscription, attributeName, attributeValue);
     snsStore.persistence?.updateSubscriptionAttributes(subscriptionArn, subscription.attributes);
   }
 

--- a/src/sns/actions/setSubscriptionAttributes.ts
+++ b/src/sns/actions/setSubscriptionAttributes.ts
@@ -44,6 +44,9 @@ export function setSubscriptionAttributes(
     if (attributeName === "FilterPolicy" || attributeName === "FilterPolicyScope") {
       subscription.parsedFilterPolicy = undefined;
     }
+    if (attributeName === "RedrivePolicy") {
+      subscription.parsedRedrivePolicy = undefined;
+    }
     snsStore.persistence?.updateSubscriptionAttributes(subscriptionArn, subscription.attributes);
   }
 

--- a/src/sns/actions/subscribe.ts
+++ b/src/sns/actions/subscribe.ts
@@ -3,6 +3,7 @@ import { SnsError } from "../../common/errors.ts";
 import { snsSuccessResponse, escapeXml } from "../../common/xml.ts";
 import type { SnsStore } from "../snsStore.ts";
 import { validateFilterPolicyLimits } from "../filter.ts";
+import { validateSubscriptionRedrivePolicy } from "../subscriptionRedrivePolicy.ts";
 
 export function subscribe(params: Record<string, string>, snsStore: SnsStore): string {
   const topicArn = params.TopicArn;
@@ -63,6 +64,9 @@ export function subscribe(params: Record<string, string>, snsStore: SnsStore): s
 
   if (resolvedAttributes.FilterPolicy) {
     validateFilterPolicyLimits(resolvedAttributes.FilterPolicy);
+  }
+  if (resolvedAttributes.RedrivePolicy !== undefined) {
+    validateSubscriptionRedrivePolicy(resolvedAttributes.RedrivePolicy);
   }
 
   const subscription = snsStore.subscribe(

--- a/src/sns/snsStore.ts
+++ b/src/sns/snsStore.ts
@@ -217,3 +217,23 @@ export class SnsStore {
     this.subscriptions.clear();
   }
 }
+
+/**
+ * Write a subscription attribute and invalidate any cached parsed form. The
+ * only sanctioned way to mutate `subscription.attributes` for keys that have
+ * derived caches (FilterPolicy, FilterPolicyScope, RedrivePolicy) — callers
+ * that reach into `attributes` directly will leave stale cache entries.
+ */
+export function setSubscriptionAttribute(
+  subscription: SnsSubscription,
+  name: string,
+  value: string,
+): void {
+  subscription.attributes[name] = value;
+  if (name === "FilterPolicy" || name === "FilterPolicyScope") {
+    subscription.parsedFilterPolicy = undefined;
+  }
+  if (name === "RedrivePolicy") {
+    subscription.parsedRedrivePolicy = undefined;
+  }
+}

--- a/src/sns/snsTypes.ts
+++ b/src/sns/snsTypes.ts
@@ -15,6 +15,11 @@ export interface SnsSubscription {
   attributes: Record<string, string>;
   /** Cached parsed FilterPolicy — invalidated when attributes change. */
   parsedFilterPolicy?: Record<string, unknown>;
+  /**
+   * Cached parsed RedrivePolicy. `undefined` = not parsed yet;
+   * `null` = absent or malformed. Invalidated when attributes change.
+   */
+  parsedRedrivePolicy?: { deadLetterTargetArn?: string } | null;
 }
 
 export interface SnsMessageAttribute {

--- a/src/sns/subscriptionRedrivePolicy.ts
+++ b/src/sns/subscriptionRedrivePolicy.ts
@@ -1,0 +1,75 @@
+import { SnsError } from "../common/errors.ts";
+
+/** Parsed shape of a subscription RedrivePolicy; we only care about the DLQ ARN. */
+export interface ParsedSubscriptionRedrivePolicy {
+  deadLetterTargetArn?: string;
+}
+
+/**
+ * Validate a RedrivePolicy attribute value at write time (Subscribe /
+ * SetSubscriptionAttributes). Mirrors how AWS rejects malformed input
+ * synchronously rather than silently dropping messages at publish time.
+ *
+ * An empty string is allowed: SetSubscriptionAttributes uses it to clear the
+ * policy. Any non-empty value must parse to a JSON object; if
+ * `deadLetterTargetArn` is present it must be a string.
+ */
+export function validateSubscriptionRedrivePolicy(raw: string): void {
+  if (raw === "") return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new SnsError(
+      "InvalidParameter",
+      "Invalid parameter: RedrivePolicy: Amazon SNS was unable to parse RedrivePolicy as JSON.",
+    );
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new SnsError(
+      "InvalidParameter",
+      "Invalid parameter: RedrivePolicy: must be a JSON object.",
+    );
+  }
+
+  const dlqArn = (parsed as { deadLetterTargetArn?: unknown }).deadLetterTargetArn;
+  if (dlqArn !== undefined && typeof dlqArn !== "string") {
+    throw new SnsError(
+      "InvalidParameter",
+      "Invalid parameter: RedrivePolicy: deadLetterTargetArn must be a string ARN.",
+    );
+  }
+}
+
+/**
+ * Parse a stored RedrivePolicy value defensively. Returns `null` when the
+ * value is absent, malformed, or doesn't conform to the expected shape —
+ * write-time validation should already have rejected malformed input, but
+ * subscriptions loaded from older persistence snapshots may not have been
+ * validated, so we narrow here too.
+ */
+export function parseSubscriptionRedrivePolicy(
+  raw: string | undefined,
+): ParsedSubscriptionRedrivePolicy | null {
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const dlqArn = (parsed as { deadLetterTargetArn?: unknown }).deadLetterTargetArn;
+  if (dlqArn !== undefined && typeof dlqArn !== "string") {
+    return null;
+  }
+
+  return { deadLetterTargetArn: dlqArn };
+}

--- a/src/spy.ts
+++ b/src/spy.ts
@@ -14,8 +14,13 @@ export interface SqsSpyMessage {
   timestamp: number;
 }
 
-/** Possible statuses for an SNS spy message. */
-export type SnsSpyMessageStatus = "published";
+/**
+ * Possible statuses for an SNS spy message.
+ * - `published`: the publish API call succeeded (one event per Publish/PublishBatch entry).
+ * - `dlq`: a fan-out delivery was rerouted to the subscription's RedrivePolicy DLQ
+ *   (one event per affected subscription, in addition to the original `published` event).
+ */
+export type SnsSpyMessageStatus = "published" | "dlq";
 
 /** An SNS event captured by {@link MessageSpy}. */
 export interface SnsSpyMessage {

--- a/test/persistence/persistence.test.ts
+++ b/test/persistence/persistence.test.ts
@@ -879,6 +879,61 @@ describe("Persistence", () => {
     await server.stop();
   });
 
+  it("SNS: subscription DLQ routing works after restart", async () => {
+    let server = await startFauxqs({ port: 0, logger: false, dataDir });
+    let sns = makeSnsClient(server.port);
+    let sqs = makeSqsClient(server.port);
+
+    await sqs.send(new CreateQueueCommand({ QueueName: "dlq-restart-endpoint" }));
+    await sqs.send(new CreateQueueCommand({ QueueName: "dlq-restart-target" }));
+    const dlqArn = "arn:aws:sqs:us-east-1:000000000000:dlq-restart-target";
+
+    const { TopicArn } = await sns.send(
+      new CreateTopicCommand({ Name: "dlq-restart-topic" }),
+    );
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn,
+        Protocol: "sqs",
+        Endpoint: "arn:aws:sqs:us-east-1:000000000000:dlq-restart-endpoint",
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlqArn }),
+        },
+      }),
+    );
+
+    await server.stop();
+
+    // Restart, delete the endpoint queue, publish — DLQ should still resolve
+    // even though the in-memory parsedRedrivePolicy cache starts fresh.
+    server = await startFauxqs({ port: 0, logger: false, dataDir });
+    sns = makeSnsClient(server.port);
+    sqs = makeSqsClient(server.port);
+
+    await sqs.send(
+      new DeleteQueueCommand({
+        QueueUrl: `http://sqs.us-east-1.localhost:${server.port}/000000000000/dlq-restart-endpoint`,
+      }),
+    );
+
+    await sns.send(
+      new PublishCommand({ TopicArn: TopicArn!, Message: "after-restart" }),
+    );
+
+    const recv = await sqs.send(
+      new ReceiveMessageCommand({
+        QueueUrl: `http://sqs.us-east-1.localhost:${server.port}/000000000000/dlq-restart-target`,
+        MaxNumberOfMessages: 1,
+        WaitTimeSeconds: 2,
+      }),
+    );
+    expect(recv.Messages).toHaveLength(1);
+    const envelope = JSON.parse(recv.Messages![0].Body!);
+    expect(envelope.Message).toBe("after-restart");
+
+    await server.stop();
+  });
+
   it("SNS: topic deletion persists", async () => {
     let server = await startFauxqs({ port: 0, logger: false, dataDir });
     let sns = makeSnsClient(server.port);

--- a/test/sns/subscription-dlq.test.ts
+++ b/test/sns/subscription-dlq.test.ts
@@ -3,10 +3,12 @@ import {
   CreateTopicCommand,
   SubscribeCommand,
   PublishCommand,
+  PublishBatchCommand,
   SetSubscriptionAttributesCommand,
 } from "@aws-sdk/client-sns";
 import {
   CreateQueueCommand,
+  DeleteMessageCommand,
   DeleteQueueCommand,
   GetQueueAttributesCommand,
   ReceiveMessageCommand,
@@ -17,8 +19,11 @@ import { startFauxqsTestServer, type FauxqsServer } from "../helpers/setup.js";
 async function createQueueWithArn(
   sqs: ReturnType<typeof createSqsClient>,
   name: string,
+  attributes?: Record<string, string>,
 ): Promise<{ url: string; arn: string }> {
-  const queue = await sqs.send(new CreateQueueCommand({ QueueName: name }));
+  const queue = await sqs.send(
+    new CreateQueueCommand({ QueueName: name, Attributes: attributes }),
+  );
   const attrs = await sqs.send(
     new GetQueueAttributesCommand({
       QueueUrl: queue.QueueUrl!,
@@ -264,5 +269,410 @@ describe("SNS Subscription DLQ (RedrivePolicy)", () => {
     expect(inB.Messages).toHaveLength(1);
     const envelope = JSON.parse(inB.Messages![0].Body!);
     expect(envelope.Message).toBe("second");
+  });
+
+  it("adds AWS.SNS.MessageId and AWS.SNS.TopicARN attributes on the DLQ message", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-correlation" }),
+    );
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-correlation-endpoint");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-correlation-dlq");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    const published = await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "with-correlation" }),
+    );
+
+    const received = await sqs.send(
+      new ReceiveMessageCommand({
+        QueueUrl: dlq.url,
+        MaxNumberOfMessages: 1,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+    expect(received.Messages).toHaveLength(1);
+    const attrs = received.Messages![0].MessageAttributes!;
+    expect(attrs["AWS.SNS.MessageId"]?.StringValue).toBe(published.MessageId);
+    expect(attrs["AWS.SNS.TopicARN"]?.StringValue).toBe(topic.TopicArn);
+  });
+
+  it("uses a single RequestID for all DLQ-routed deliveries from one publish", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-shared-request-id" }),
+    );
+    const endpointA = await createQueueWithArn(sqs, "sub-dlq-shared-a-endpoint");
+    const endpointB = await createQueueWithArn(sqs, "sub-dlq-shared-b-endpoint");
+    const dlqA = await createQueueWithArn(sqs, "sub-dlq-shared-a-dlq");
+    const dlqB = await createQueueWithArn(sqs, "sub-dlq-shared-b-dlq");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpointA.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlqA.arn }),
+        },
+      }),
+    );
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpointB.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlqB.arn }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpointA.url }));
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpointB.url }));
+
+    await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "fan-out" }),
+    );
+
+    const inA = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlqA.url, MessageAttributeNames: ["All"] }),
+    );
+    const inB = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlqB.url, MessageAttributeNames: ["All"] }),
+    );
+    expect(inA.Messages).toHaveLength(1);
+    expect(inB.Messages).toHaveLength(1);
+    const reqIdA = inA.Messages![0].MessageAttributes!.RequestID?.StringValue;
+    const reqIdB = inB.Messages![0].MessageAttributes!.RequestID?.StringValue;
+    expect(reqIdA).toBeDefined();
+    expect(reqIdA).toBe(reqIdB);
+  });
+
+  it("does not route filtered-out messages to the DLQ", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sub-dlq-filtered" }));
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-filtered-endpoint");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-filtered-dlq");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          FilterPolicy: JSON.stringify({ color: ["blue"] }),
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    // Publish a message that doesn't match the filter — should be dropped
+    // entirely (filter wins before delivery resolution), not redriven.
+    await sns.send(
+      new PublishCommand({
+        TopicArn: topic.TopicArn!,
+        Message: "filtered out",
+        MessageAttributes: {
+          color: { DataType: "String", StringValue: "red" },
+        },
+      }),
+    );
+
+    const inDlq = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlq.url, WaitTimeSeconds: 0 }),
+    );
+    expect(inDlq.Messages ?? []).toHaveLength(0);
+  });
+
+  it("routes only the subscribers with a configured DLQ when fanning out to a mix", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-mixed-subs" }),
+    );
+    const endpointWithDlq = await createQueueWithArn(sqs, "sub-dlq-mixed-with");
+    const endpointWithoutDlq = await createQueueWithArn(sqs, "sub-dlq-mixed-without");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-mixed-dlq");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpointWithDlq.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpointWithoutDlq.arn,
+      }),
+    );
+
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpointWithDlq.url }));
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpointWithoutDlq.url }));
+
+    await sns.send(new PublishCommand({ TopicArn: topic.TopicArn!, Message: "mixed" }));
+
+    const inDlq = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlq.url, MaxNumberOfMessages: 5 }),
+    );
+    expect(inDlq.Messages ?? []).toHaveLength(1);
+  });
+
+  it("routes PublishBatch deliveries to the subscription DLQ", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sub-dlq-batch" }));
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-batch-endpoint");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-batch-dlq");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishBatchCommand({
+        TopicArn: topic.TopicArn!,
+        PublishBatchRequestEntries: [
+          { Id: "1", Message: "batch-1" },
+          { Id: "2", Message: "batch-2" },
+        ],
+      }),
+    );
+
+    const received = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlq.url, MaxNumberOfMessages: 10 }),
+    );
+    expect(received.Messages ?? []).toHaveLength(2);
+    const bodies = received
+      .Messages!.map((m) => JSON.parse(m.Body!).Message)
+      .sort();
+    expect(bodies).toEqual(["batch-1", "batch-2"]);
+  });
+
+  it("routes FIFO topic deliveries to a FIFO DLQ with sequence numbers", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({
+        Name: `sub-dlq-fifo-${Date.now()}.fifo`,
+        Attributes: { FifoTopic: "true", ContentBasedDeduplication: "true" },
+      }),
+    );
+    const endpoint = await createQueueWithArn(
+      sqs,
+      `sub-dlq-fifo-endpoint-${Date.now()}.fifo`,
+      { FifoQueue: "true", ContentBasedDeduplication: "true" },
+    );
+    const dlq = await createQueueWithArn(
+      sqs,
+      `sub-dlq-fifo-dlq-${Date.now()}.fifo`,
+      { FifoQueue: "true", ContentBasedDeduplication: "true" },
+    );
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishCommand({
+        TopicArn: topic.TopicArn!,
+        Message: "fifo-1",
+        MessageGroupId: "g1",
+      }),
+    );
+    await sns.send(
+      new PublishCommand({
+        TopicArn: topic.TopicArn!,
+        Message: "fifo-2",
+        MessageGroupId: "g1",
+      }),
+    );
+
+    // FIFO receive locks the message group until ack — drain in two calls,
+    // deleting between them.
+    const first = await sqs.send(
+      new ReceiveMessageCommand({
+        QueueUrl: dlq.url,
+        MaxNumberOfMessages: 10,
+        AttributeNames: ["All"],
+      }),
+    );
+    expect(first.Messages).toHaveLength(1);
+    expect(JSON.parse(first.Messages![0].Body!).Message).toBe("fifo-1");
+    expect(first.Messages![0].Attributes?.SequenceNumber).toBeDefined();
+
+    await sqs.send(
+      new DeleteMessageCommand({
+        QueueUrl: dlq.url,
+        ReceiptHandle: first.Messages![0].ReceiptHandle!,
+      }),
+    );
+
+    const second = await sqs.send(
+      new ReceiveMessageCommand({
+        QueueUrl: dlq.url,
+        MaxNumberOfMessages: 10,
+        AttributeNames: ["All"],
+      }),
+    );
+    expect(second.Messages).toHaveLength(1);
+    expect(JSON.parse(second.Messages![0].Body!).Message).toBe("fifo-2");
+    expect(second.Messages![0].Attributes?.SequenceNumber).toBeDefined();
+  });
+
+  it("routes FIFO topic deliveries to a non-FIFO DLQ", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({
+        Name: `sub-dlq-fifo-nonfifo-${Date.now()}.fifo`,
+        Attributes: { FifoTopic: "true", ContentBasedDeduplication: "true" },
+      }),
+    );
+    const endpoint = await createQueueWithArn(
+      sqs,
+      `sub-dlq-fifo-nonfifo-endpoint-${Date.now()}.fifo`,
+      { FifoQueue: "true", ContentBasedDeduplication: "true" },
+    );
+    // Non-FIFO DLQ — supported per AWS, useful when the operator wants a
+    // simple sink without ordering guarantees.
+    const dlq = await createQueueWithArn(sqs, `sub-dlq-fifo-nonfifo-dlq-${Date.now()}`);
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishCommand({
+        TopicArn: topic.TopicArn!,
+        Message: "fifo-to-standard",
+        MessageGroupId: "g1",
+      }),
+    );
+
+    const received = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlq.url, MaxNumberOfMessages: 1 }),
+    );
+    expect(received.Messages).toHaveLength(1);
+    expect(JSON.parse(received.Messages![0].Body!).Message).toBe("fifo-to-standard");
+  });
+
+  it("rejects malformed RedrivePolicy at SetSubscriptionAttributes", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-malformed-set" }),
+    );
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-malformed-set-endpoint");
+
+    const sub = await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+      }),
+    );
+
+    await expect(
+      sns.send(
+        new SetSubscriptionAttributesCommand({
+          SubscriptionArn: sub.SubscriptionArn!,
+          AttributeName: "RedrivePolicy",
+          AttributeValue: "not json",
+        }),
+      ),
+    ).rejects.toThrow(/RedrivePolicy/);
+
+    await expect(
+      sns.send(
+        new SetSubscriptionAttributesCommand({
+          SubscriptionArn: sub.SubscriptionArn!,
+          AttributeName: "RedrivePolicy",
+          AttributeValue: JSON.stringify({ deadLetterTargetArn: 42 }),
+        }),
+      ),
+    ).rejects.toThrow(/RedrivePolicy/);
+
+    await expect(
+      sns.send(
+        new SetSubscriptionAttributesCommand({
+          SubscriptionArn: sub.SubscriptionArn!,
+          AttributeName: "RedrivePolicy",
+          AttributeValue: "[1, 2, 3]",
+        }),
+      ),
+    ).rejects.toThrow(/RedrivePolicy/);
+  });
+
+  it("rejects malformed RedrivePolicy at Subscribe", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-malformed-subscribe" }),
+    );
+    const endpoint = await createQueueWithArn(
+      sqs,
+      "sub-dlq-malformed-subscribe-endpoint",
+    );
+
+    await expect(
+      sns.send(
+        new SubscribeCommand({
+          TopicArn: topic.TopicArn!,
+          Protocol: "sqs",
+          Endpoint: endpoint.arn,
+          Attributes: { RedrivePolicy: "not json" },
+        }),
+      ),
+    ).rejects.toThrow(/RedrivePolicy/);
+  });
+
+  it("still accepts an empty-object RedrivePolicy (no effective DLQ)", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-empty-policy" }),
+    );
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-empty-policy-endpoint");
+
+    const sub = await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: { RedrivePolicy: "{}" },
+      }),
+    );
+    expect(sub.SubscriptionArn).toBeDefined();
+
+    // Empty policy followed by missing endpoint should silently drop, not throw.
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+    await expect(
+      sns.send(new PublishCommand({ TopicArn: topic.TopicArn!, Message: "x" })),
+    ).resolves.toBeDefined();
   });
 });

--- a/test/sns/subscription-dlq.test.ts
+++ b/test/sns/subscription-dlq.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  CreateTopicCommand,
+  SubscribeCommand,
+  PublishCommand,
+  SetSubscriptionAttributesCommand,
+} from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  DeleteQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+import { createSnsClient, createSqsClient } from "../helpers/clients.js";
+import { startFauxqsTestServer, type FauxqsServer } from "../helpers/setup.js";
+
+async function createQueueWithArn(
+  sqs: ReturnType<typeof createSqsClient>,
+  name: string,
+): Promise<{ url: string; arn: string }> {
+  const queue = await sqs.send(new CreateQueueCommand({ QueueName: name }));
+  const attrs = await sqs.send(
+    new GetQueueAttributesCommand({
+      QueueUrl: queue.QueueUrl!,
+      AttributeNames: ["QueueArn"],
+    }),
+  );
+  return { url: queue.QueueUrl!, arn: attrs.Attributes!.QueueArn! };
+}
+
+describe("SNS Subscription DLQ (RedrivePolicy)", () => {
+  let server: FauxqsServer;
+  let sns: ReturnType<typeof createSnsClient>;
+  let sqs: ReturnType<typeof createSqsClient>;
+
+  beforeAll(async () => {
+    server = await startFauxqsTestServer();
+    sns = createSnsClient(server.port);
+    sqs = createSqsClient(server.port);
+  });
+
+  afterAll(async () => {
+    sns.destroy();
+    sqs.destroy();
+    await server.stop();
+  });
+
+  it("routes wrapped delivery to subscription DLQ when endpoint queue is gone", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sub-dlq-wrapped" }));
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-wrapped-endpoint");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-wrapped-dlq");
+
+    const sub = await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+      }),
+    );
+    await sns.send(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: sub.SubscriptionArn!,
+        AttributeName: "RedrivePolicy",
+        AttributeValue: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+      }),
+    );
+
+    // Force a delivery failure: the subscription still exists but the
+    // endpoint queue does not.
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishCommand({
+        TopicArn: topic.TopicArn!,
+        Message: "sub-dlq-1",
+      }),
+    );
+
+    const received = await sqs.send(
+      new ReceiveMessageCommand({
+        QueueUrl: dlq.url,
+        MaxNumberOfMessages: 1,
+        MessageAttributeNames: ["All"],
+      }),
+    );
+
+    expect(received.Messages).toHaveLength(1);
+    const envelope = JSON.parse(received.Messages![0].Body!);
+    expect(envelope.Type).toBe("Notification");
+    expect(envelope.Message).toBe("sub-dlq-1");
+    expect(envelope.TopicArn).toBe(topic.TopicArn);
+
+    const attrs = received.Messages![0].MessageAttributes!;
+    expect(attrs.ErrorCode?.StringValue).toBe(
+      "AWS.SimpleQueueService.NonExistentQueue",
+    );
+    expect(attrs.ErrorMessage?.StringValue).toBe(
+      "The specified queue does not exist or you do not have access to it.",
+    );
+    expect(attrs.RequestID?.StringValue).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("preserves RawMessageDelivery body when routing to DLQ", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sub-dlq-raw" }));
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-raw-endpoint");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-raw-dlq");
+
+    const sub = await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RawMessageDelivery: "true",
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+    expect(sub.SubscriptionArn).toBeDefined();
+
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "raw-dlq-payload" }),
+    );
+
+    const received = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlq.url, MaxNumberOfMessages: 1 }),
+    );
+
+    expect(received.Messages).toHaveLength(1);
+    expect(received.Messages![0].Body).toBe("raw-dlq-payload");
+  });
+
+  it("drops the message when endpoint is missing and no RedrivePolicy is set", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sub-dlq-none" }));
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-none-endpoint");
+    const observer = await createQueueWithArn(sqs, "sub-dlq-none-observer");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "lost" }),
+    );
+
+    // Nothing should arrive in an unrelated queue either — sanity check that
+    // the message is silently dropped (existing behaviour) when no DLQ.
+    const received = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: observer.url, WaitTimeSeconds: 0 }),
+    );
+    expect(received.Messages ?? []).toHaveLength(0);
+  });
+
+  it("drops the message when RedrivePolicy targets a non-existent DLQ", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-missing-target" }),
+    );
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-missing-target-endpoint");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({
+            deadLetterTargetArn:
+              "arn:aws:sqs:us-east-1:000000000000:does-not-exist-dlq",
+          }),
+        },
+      }),
+    );
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    // Should not throw — the publish succeeds, the message is simply dropped
+    // because there's nowhere left to route it. This matches the
+    // best-effort nature of SNS delivery.
+    await expect(
+      sns.send(new PublishCommand({ TopicArn: topic.TopicArn!, Message: "lost" })),
+    ).resolves.toBeDefined();
+  });
+
+  it("does not route to DLQ when delivery succeeds normally", async () => {
+    const topic = await sns.send(new CreateTopicCommand({ Name: "sub-dlq-happy" }));
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-happy-endpoint");
+    const dlq = await createQueueWithArn(sqs, "sub-dlq-happy-dlq");
+
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.arn }),
+        },
+      }),
+    );
+
+    await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "happy path" }),
+    );
+
+    const endpointMsg = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: endpoint.url }),
+    );
+    expect(endpointMsg.Messages).toHaveLength(1);
+
+    const dlqMsg = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: dlq.url, WaitTimeSeconds: 0 }),
+    );
+    expect(dlqMsg.Messages ?? []).toHaveLength(0);
+  });
+
+  it("invalidates the cached RedrivePolicy when SetSubscriptionAttributes changes it", async () => {
+    const topic = await sns.send(
+      new CreateTopicCommand({ Name: "sub-dlq-cache-invalidate" }),
+    );
+    const endpoint = await createQueueWithArn(sqs, "sub-dlq-cache-endpoint");
+    const dlqA = await createQueueWithArn(sqs, "sub-dlq-cache-a");
+    const dlqB = await createQueueWithArn(sqs, "sub-dlq-cache-b");
+
+    const sub = await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: endpoint.arn,
+        Attributes: {
+          RedrivePolicy: JSON.stringify({ deadLetterTargetArn: dlqA.arn }),
+        },
+      }),
+    );
+
+    await sqs.send(new DeleteQueueCommand({ QueueUrl: endpoint.url }));
+
+    await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "first" }),
+    );
+    const inA = await sqs.send(new ReceiveMessageCommand({ QueueUrl: dlqA.url }));
+    expect(inA.Messages).toHaveLength(1);
+
+    // Repoint the RedrivePolicy at the second DLQ. Without cache
+    // invalidation we'd keep delivering to dlqA.
+    await sns.send(
+      new SetSubscriptionAttributesCommand({
+        SubscriptionArn: sub.SubscriptionArn!,
+        AttributeName: "RedrivePolicy",
+        AttributeValue: JSON.stringify({ deadLetterTargetArn: dlqB.arn }),
+      }),
+    );
+    await sns.send(
+      new PublishCommand({ TopicArn: topic.TopicArn!, Message: "second" }),
+    );
+
+    const inB = await sqs.send(new ReceiveMessageCommand({ QueueUrl: dlqB.url }));
+    expect(inB.Messages).toHaveLength(1);
+    const envelope = JSON.parse(inB.Messages![0].Body!);
+    expect(envelope.Message).toBe("second");
+  });
+});


### PR DESCRIPTION
## Summary

- Honour `RedrivePolicy` on SNS subscriptions: when the SQS endpoint queue is missing at publish time, deliver the message to `deadLetterTargetArn` instead of silently dropping it.
- Attach AWS-faithful `RequestID`, `ErrorCode` (`AWS.SimpleQueueService.NonExistentQueue`), and `ErrorMessage` (`"The specified queue does not exist or you do not have access to it."`) message attributes — verified against the [AWS DLQ docs](https://docs.aws.amazon.com/sns/latest/dg/sns-dead-letter-queues.html) and the [re:Post knowledge-center article](https://repost.aws/knowledge-center/sns-sqs-subscriptions-notifications). Shape also matches LocalStack's `sns_error_to_dead_letter_queue`.
- Cache parsed `RedrivePolicy` on the subscription (same pattern as `parsedFilterPolicy`) and invalidate it from `SetSubscriptionAttributes`.

## Why

Downstream consumers (e.g. [message-queue-toolkit#446](https://github.com/kibertoad/message-queue-toolkit/pull/446)) currently `it.skipIf(!isLocalstack)` for the "routes undeliverable messages to the consumer DLQ when the endpoint queue is gone" test because fauxqs dropped on missing endpoint. Once this lands and is released, that guard can be removed.

## Test plan

- [x] New `test/sns/subscription-dlq.test.ts` covers: wrapped delivery → DLQ, raw delivery → DLQ, no `RedrivePolicy` still drops, `RedrivePolicy` targeting a non-existent DLQ drops (no throw), happy path is unaffected, `SetSubscriptionAttributes` cache invalidation works.
- [x] Full suite: 889 tests / 107 files passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SNS subscriptions now support automatic message routing to dead-letter queues when the primary endpoint queue becomes unavailable. Messages include standard SNS error codes and details.

* **Documentation**
  * Updated SNS subscription configuration documentation to clarify dead-letter queue routing behavior, error attributes, and RedrivePolicy configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kibertoad/fauxqs/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->