### PR TITLE
feat(sqs): randomize standard (non-FIFO) delivery order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@d1b52cc4c7e618b19de8a43c7138213b277e820c # v3
+      - uses: fastify/github-action-merge-dependabot@73ec4cbb5e56df5591eae286972d5b2201ffe90f # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@73ec4cbb5e56df5591eae286972d5b2201ffe90f # v3
+      - uses: fastify/github-action-merge-dependabot@73ec4cbb5e56df5591eae286972d5b2201ffe90f # v3.15.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ const server = await startFauxqs({
 |------|---------|-------------|
 | `disableMinCopySourceSize` | `false` | AWS requires the source object to be [larger than 5 MiB](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html) for byte-range `UploadPartCopy`. Set to `true` to allow byte-range copies from smaller sources. |
 
+#### Message ordering
+
+Standard (non-FIFO) SQS queues and standard SNS topics give **no ordering guarantee** on real AWS — messages can be delivered out of the order they were sent. fauxqs reflects this: it delivers standard-queue messages in a **random order** so that consumers which implicitly rely on ordering fail locally instead of in production. This applies to messages received directly from a standard queue as well as messages fanned out from a standard SNS topic.
+
+There is intentionally **no option to force strict ordering on a standard queue** — that would replicate behaviour real AWS does not provide. If you need ordering, use a **FIFO queue** (`.fifo` suffix / `FifoQueue: "true"`), which fauxqs delivers in strict per-message-group order.
+
+For deterministic tests or to reproduce a specific interleaving, seed the reordering PRNG. The same seed always produces the same delivery order:
+
+```typescript
+const server = await startFauxqs({
+  port: 0,
+  ordering: { seed: 42 },
+});
+```
+
+The seed can also be set via the `FAUXQS_ORDERING_SEED` environment variable. Without a seed, ordering is non-deterministic across runs.
+
 #### Programmatic state setup
 
 The server object exposes methods for pre-creating resources without going through the SDK:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The server starts on port `4566` and handles SQS, SNS, and S3 on a single endpoi
 | `FAUXQS_DATA_DIR` | Directory for SQLite persistence (see [Persistence](#persistence)). Omit to keep all state in-memory. | (none) |
 | `FAUXQS_PERSISTENCE` | Set to `true` to enable persistence when `FAUXQS_DATA_DIR` is set | `false` |
 | `FAUXQS_S3_STORAGE_DIR` | Directory for file-based S3 object storage (see [File-based S3 storage](#file-based-s3-storage)). Independent of `FAUXQS_DATA_DIR`. | (none) |
+| `FAUXQS_ORDERING_SEED` | Seed for the standard-queue reordering PRNG, for deterministic delivery order (see [Message ordering](#message-ordering)). Omit for non-deterministic ordering. | (none) |
 | `FAUXQS_DNS_NAME` | Domain that dnsmasq resolves (including all subdomains) to the container IP. Only needed when the container hostname doesn't match the docker-compose service name — e.g., when using `container_name` or running with plain `docker run`. In docker-compose the hostname is set to the service name automatically, so this is rarely needed. (Docker only) | container hostname |
 | `FAUXQS_DNS_UPSTREAM` | Where dnsmasq forwards non-fauxqs DNS queries (e.g., `registry.npmjs.org`). Change this if you're in a corporate network with an internal DNS server, or if you prefer a different public resolver like `1.1.1.1`. (Docker only) | `8.8.8.8` |
 

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
     "node": ">=22.5.0",
     "pnpm": ">=11"
   },
-  "packageManager": "pnpm@11.2.1"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,7 @@ import { S3NotificationDispatcher } from "./s3/notifications.ts";
 import { getCallerIdentity } from "./sts/getCallerIdentity.ts";
 import { sqsQueueArn, snsTopicArn } from "./common/arnHelper.ts";
 import { DEFAULT_REGION, SNS_MAX_MESSAGE_SIZE_BYTES } from "./common/types.ts";
+import { mulberry32 } from "./common/prng.ts";
 import { loadInitConfig, applyInitConfig } from "./initConfig.ts";
 import { MessageSpy, type MessageSpyReader } from "./spy.ts";
 import { PersistenceManager } from "./persistence.ts";
@@ -97,6 +98,9 @@ export interface BuildAppOptions {
   stores?: { sqsStore: SqsStore; snsStore: SnsStore; s3Store: S3Store };
   relaxedRules?: RelaxedRules;
   tenantManager?: TenantManager;
+  /** Seed for the standard-queue reordering PRNG. Standard queues always reorder (real SQS/SNS give no
+   *  ordering guarantee); a seed only makes that reordering deterministic. Use a FIFO queue if you need ordering. */
+  ordering?: { seed?: number };
 }
 
 export function buildApp(options?: BuildAppOptions) {
@@ -161,6 +165,9 @@ export function buildApp(options?: BuildAppOptions) {
   }
   if (options?.defaultRegion) {
     sqsStore.region = options.defaultRegion;
+  }
+  if (options?.ordering?.seed !== undefined) {
+    sqsStore.random = mulberry32(options.ordering.seed);
   }
   const snsStore = options?.stores?.snsStore ?? new SnsStore();
   if (options?.defaultRegion) {
@@ -470,6 +477,10 @@ export async function startFauxqs(options?: {
   s3StorageDir?: string;
   /** Multi-tenant configuration. When set, enables auto-cleanup, templated creation, and permanent prefix management. */
   tenant?: TenantConfig;
+  /** Seed for the standard-queue reordering PRNG. Standard queues always reorder (real SQS/SNS give no
+   *  ordering guarantee); a seed only makes that reordering deterministic. Use a FIFO queue if you need ordering.
+   *  Env fallback: FAUXQS_ORDERING_SEED. */
+  ordering?: { seed?: number };
 }): Promise<FauxqsServer> {
   const port = options?.port ?? parseInt(process.env.FAUXQS_PORT ?? "4566");
   const host = options?.host ?? process.env.FAUXQS_HOST;
@@ -484,6 +495,15 @@ export async function startFauxqs(options?: {
   const sqsStore = usageTracker ? new TrackedSqsStore(usageTracker) : new SqsStore();
   const snsStore = usageTracker ? new TrackedSnsStore(usageTracker) : new SnsStore();
   const s3Store = usageTracker ? new TrackedS3Store(usageTracker) : new S3Store();
+
+  // Seed the standard-queue reordering PRNG before any queues are created (incl. during
+  // persistence load, which uses createQueue and propagates this.random to each queue).
+  const orderingSeed =
+    options?.ordering?.seed ??
+    (process.env.FAUXQS_ORDERING_SEED ? parseInt(process.env.FAUXQS_ORDERING_SEED) : undefined);
+  if (orderingSeed !== undefined && !Number.isNaN(orderingSeed)) {
+    sqsStore.random = mulberry32(orderingSeed);
+  }
 
   // Persistence: create managers and wire into stores before any data is loaded
   const persistenceManager = options?.dataDir ? new PersistenceManager(options.dataDir) : undefined;

--- a/src/common/prng.ts
+++ b/src/common/prng.ts
@@ -1,0 +1,11 @@
+/** Deterministic PRNG for reproducible message reordering. Returns a () => number in [0, 1). */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/sqs/sqsStore.ts
+++ b/src/sqs/sqsStore.ts
@@ -721,8 +721,20 @@ export class SqsStore {
   region?: string;
   spy?: MessageSpy;
   persistence?: PersistenceManager;
+  private _random: () => number = Math.random;
+
   /** PRNG shared with every queue for standard-queue reordering. Seeded via the `ordering` option. */
-  random: () => number = Math.random;
+  get random(): () => number {
+    return this._random;
+  }
+
+  /** Reseeding propagates to already-created queues, not just future ones. */
+  set random(random: () => number) {
+    this._random = random;
+    for (const queue of this.queues.values()) {
+      queue.random = random;
+    }
+  }
 
   createQueue(
     name: string,
@@ -732,7 +744,7 @@ export class SqsStore {
     tags?: Record<string, string>,
   ): SqsQueue {
     const queue = new SqsQueue(name, url, arn, attributes, tags);
-    queue.random = this.random;
+    queue.random = this._random;
     if (this.spy) {
       queue.spy = this.spy;
     }

--- a/src/sqs/sqsStore.ts
+++ b/src/sqs/sqsStore.ts
@@ -42,6 +42,8 @@ export class SqsQueue {
 
   spy?: MessageSpy;
   persistence?: PersistenceManager;
+  /** PRNG for standard-queue reordering; injected from the store so all queues share one (optionally seeded) stream. */
+  random: () => number = Math.random;
 
   // FIFO-specific fields
   fifoMessages: Map<string, SqsMessage[]> = new Map();
@@ -219,7 +221,15 @@ export class SqsQueue {
     let collected = 0;
 
     while (collected < count && this.messages.length > 0) {
-      const msg = this.messages.shift();
+      // Standard queues give no ordering guarantee — select a random ready message
+      // instead of strict FIFO. Use a FIFO queue if ordering is required.
+      let msg: SqsMessage | undefined;
+      if (this.messages.length > 1) {
+        const idx = Math.floor(this.random() * this.messages.length);
+        msg = this.messages.splice(idx, 1)[0];
+      } else {
+        msg = this.messages.shift();
+      }
       if (!msg) break;
 
       msg.approximateReceiveCount++;
@@ -711,6 +721,8 @@ export class SqsStore {
   region?: string;
   spy?: MessageSpy;
   persistence?: PersistenceManager;
+  /** PRNG shared with every queue for standard-queue reordering. Seeded via the `ordering` option. */
+  random: () => number = Math.random;
 
   createQueue(
     name: string,
@@ -720,6 +732,7 @@ export class SqsStore {
     tags?: Record<string, string>,
   ): SqsQueue {
     const queue = new SqsQueue(name, url, arn, attributes, tags);
+    queue.random = this.random;
     if (this.spy) {
       queue.spy = this.spy;
     }

--- a/test/sqs/inspect.test.ts
+++ b/test/sqs/inspect.test.ts
@@ -105,16 +105,19 @@ describe("Queue inspection - programmatic API", () => {
       }),
     );
 
-    // Receive one message to make it in-flight (takes first available: msg-a)
+    // Receive one message to make it in-flight. Standard queues deliver in a
+    // non-deterministic order, so it's either msg-a or msg-b — the other stays ready.
     await sqs.send(
       new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl!, MaxNumberOfMessages: 1 }),
     );
 
     const result = server.inspectQueue("inspect-all-states")!;
     expect(result.messages.ready).toHaveLength(1);
-    expect(result.messages.ready[0].body).toBe("msg-b");
     expect(result.messages.inflight).toHaveLength(1);
-    expect(result.messages.inflight[0].message.body).toBe("msg-a");
+    // One of the two standard messages is in-flight, the other is ready.
+    expect([result.messages.inflight[0].message.body, result.messages.ready[0].body].sort()).toEqual(
+      ["msg-a", "msg-b"],
+    );
     expect(result.messages.delayed).toHaveLength(1);
     expect(result.messages.delayed[0].body).toBe("delayed-msg");
   });
@@ -217,7 +220,8 @@ describe("Queue inspection - HTTP endpoint", () => {
       new SendMessageCommand({ QueueUrl: queue.QueueUrl!, MessageBody: "msg-b" }),
     );
 
-    // Make one in-flight (takes first available: ready-msg)
+    // Make one in-flight. Standard queues deliver in a non-deterministic order,
+    // so it's either ready-msg or msg-b — the other stays ready.
     await sqs.send(
       new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl!, MaxNumberOfMessages: 1 }),
     );
@@ -230,11 +234,14 @@ describe("Queue inspection - HTTP endpoint", () => {
     expect(body.arn).toContain("http-inspect-detail");
     expect(body.attributes.VisibilityTimeout).toBe("60");
     expect(body.messages.ready).toHaveLength(1);
-    expect(body.messages.ready[0].body).toBe("msg-b");
+    expect(body.messages.inflight).toHaveLength(1);
+    // One of the two standard messages is in-flight, the other is ready.
+    expect([body.messages.inflight[0].message.body, body.messages.ready[0].body].sort()).toEqual([
+      "msg-b",
+      "ready-msg",
+    ]);
     expect(body.messages.delayed).toHaveLength(1);
     expect(body.messages.delayed[0].body).toBe("delayed-msg");
-    expect(body.messages.inflight).toHaveLength(1);
-    expect(body.messages.inflight[0].message.body).toBe("ready-msg");
   });
 
   it("inspection does not consume messages", async () => {

--- a/test/sqs/ordering.test.ts
+++ b/test/sqs/ordering.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  CreateQueueCommand,
+  SendMessageCommand,
+  ReceiveMessageCommand,
+  DeleteMessageCommand,
+  GetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import { CreateTopicCommand, SubscribeCommand, PublishCommand } from "@aws-sdk/client-sns";
+import { startFauxqs, type FauxqsServer } from "../../src/app.js";
+import { createSqsClient, createSnsClient } from "../helpers/clients.js";
+
+describe("Standard queue delivery reordering", () => {
+  let server: FauxqsServer;
+
+  afterEach(async () => {
+    await server?.stop();
+  });
+
+  async function sendMany(
+    sqs: ReturnType<typeof createSqsClient>,
+    queueUrl: string,
+    bodies: string[],
+  ): Promise<void> {
+    for (const body of bodies) {
+      await sqs.send(new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: body }));
+    }
+  }
+
+  async function receiveAll(
+    sqs: ReturnType<typeof createSqsClient>,
+    queueUrl: string,
+    count: number,
+  ): Promise<string[]> {
+    const received: string[] = [];
+    while (received.length < count) {
+      const res = await sqs.send(
+        new ReceiveMessageCommand({ QueueUrl: queueUrl, MaxNumberOfMessages: 10 }),
+      );
+      if (!res.Messages?.length) break;
+      for (const m of res.Messages) {
+        received.push(m.Body!);
+        await sqs.send(
+          new DeleteMessageCommand({ QueueUrl: queueUrl, ReceiptHandle: m.ReceiptHandle! }),
+        );
+      }
+    }
+    return received;
+  }
+
+  it("reorders standard-queue messages (not strict FIFO)", async () => {
+    server = await startFauxqs({ port: 0, logger: false, ordering: { seed: 42 } });
+    const sqs = createSqsClient(server.port);
+    const queue = await sqs.send(new CreateQueueCommand({ QueueName: "reorder-q" }));
+
+    const inOrder = Array.from({ length: 10 }, (_, i) => `msg-${i}`);
+    await sendMany(sqs, queue.QueueUrl!, inOrder);
+
+    const received = await receiveAll(sqs, queue.QueueUrl!, inOrder.length);
+
+    // Every message is delivered exactly once...
+    expect([...received].sort()).toEqual([...inOrder].sort());
+    // ...but not in strict send order (seed makes this deterministic).
+    expect(received).not.toEqual(inOrder);
+
+    sqs.destroy();
+  });
+
+  it("is reproducible for a fixed seed", async () => {
+    const inOrder = Array.from({ length: 10 }, (_, i) => `m${i}`);
+
+    server = await startFauxqs({ port: 0, logger: false, ordering: { seed: 12345 } });
+    let sqs = createSqsClient(server.port);
+    let queue = await sqs.send(new CreateQueueCommand({ QueueName: "seeded-q" }));
+    await sendMany(sqs, queue.QueueUrl!, inOrder);
+    const firstRun = await receiveAll(sqs, queue.QueueUrl!, inOrder.length);
+    sqs.destroy();
+    await server.stop();
+
+    server = await startFauxqs({ port: 0, logger: false, ordering: { seed: 12345 } });
+    sqs = createSqsClient(server.port);
+    queue = await sqs.send(new CreateQueueCommand({ QueueName: "seeded-q" }));
+    await sendMany(sqs, queue.QueueUrl!, inOrder);
+    const secondRun = await receiveAll(sqs, queue.QueueUrl!, inOrder.length);
+    sqs.destroy();
+
+    expect(secondRun).toEqual(firstRun);
+  });
+
+  it("does not reorder FIFO queues", async () => {
+    server = await startFauxqs({ port: 0, logger: false, ordering: { seed: 42 } });
+    const sqs = createSqsClient(server.port);
+    const queue = await sqs.send(
+      new CreateQueueCommand({
+        QueueName: "ordered-q.fifo",
+        Attributes: { FifoQueue: "true", ContentBasedDeduplication: "true" },
+      }),
+    );
+
+    const inOrder = Array.from({ length: 5 }, (_, i) => `fifo-${i}`);
+    for (const body of inOrder) {
+      await sqs.send(
+        new SendMessageCommand({
+          QueueUrl: queue.QueueUrl!,
+          MessageBody: body,
+          MessageGroupId: "g1",
+        }),
+      );
+    }
+
+    // One message per group per receive; delete to unlock the next.
+    const received = await receiveAll(sqs, queue.QueueUrl!, inOrder.length);
+    expect(received).toEqual(inOrder);
+
+    sqs.destroy();
+  });
+
+  it("reorders end-to-end through SNS standard topic → standard queue", async () => {
+    server = await startFauxqs({ port: 0, logger: false, ordering: { seed: 7 } });
+    const sqs = createSqsClient(server.port);
+    const sns = createSnsClient(server.port);
+
+    const queue = await sqs.send(new CreateQueueCommand({ QueueName: "sns-reorder-q" }));
+    const attrs = await sqs.send(
+      new GetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl!,
+        AttributeNames: ["QueueArn"],
+      }),
+    );
+    const topic = await sns.send(new CreateTopicCommand({ Name: "reorder-topic" }));
+    await sns.send(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn!,
+        Protocol: "sqs",
+        Endpoint: attrs.Attributes!.QueueArn!,
+        Attributes: { RawMessageDelivery: "true" },
+      }),
+    );
+
+    const inOrder = Array.from({ length: 10 }, (_, i) => `evt-${i}`);
+    for (const body of inOrder) {
+      await sns.send(new PublishCommand({ TopicArn: topic.TopicArn!, Message: body }));
+    }
+
+    const received = await receiveAll(sqs, queue.QueueUrl!, inOrder.length);
+    expect([...received].sort()).toEqual([...inOrder].sort());
+    expect(received).not.toEqual(inOrder);
+
+    sqs.destroy();
+    sns.destroy();
+  });
+});

--- a/test/sqs/ordering.test.ts
+++ b/test/sqs/ordering.test.ts
@@ -8,6 +8,8 @@ import {
 } from "@aws-sdk/client-sqs";
 import { CreateTopicCommand, SubscribeCommand, PublishCommand } from "@aws-sdk/client-sns";
 import { startFauxqs, type FauxqsServer } from "../../src/app.js";
+import { SqsStore } from "../../src/sqs/sqsStore.js";
+import { mulberry32 } from "../../src/common/prng.js";
 import { createSqsClient, createSnsClient } from "../helpers/clients.js";
 
 describe("Standard queue delivery reordering", () => {
@@ -47,6 +49,22 @@ describe("Standard queue delivery reordering", () => {
     }
     return received;
   }
+
+  it("propagates a reseed to already-created queues", () => {
+    const store = new SqsStore();
+    const queue = store.createQueue(
+      "q",
+      "http://localhost/q",
+      "arn:aws:sqs:us-east-1:000000000000:q",
+    );
+    expect(queue.random).toBe(store.random);
+
+    // Reseeding after the queue exists must reach that queue, not just future ones.
+    const seeded = mulberry32(99);
+    store.random = seeded;
+    expect(queue.random).toBe(seeded);
+    expect(queue.random).toBe(store.random);
+  });
 
   it("reorders standard-queue messages (not strict FIFO)", async () => {
     server = await startFauxqs({ port: 0, logger: false, ordering: { seed: 42 } });


### PR DESCRIPTION
## Why

A real bug recently shipped because it only manifested in production, not on PRE. Two events were published ~33 ms apart to a **standard** (non-FIFO) SNS topic and consumed from one standard SQS queue. Standard SNS → standard SQS gives **no ordering guarantee**, so on real AWS the consumer received them out of order and took the wrong branch. On PRE (backed by fauxqs) the events were always delivered in strict send order, so the race never surfaced.

**Root cause in fauxqs:** standard queues delivered in strict insertion order (`messages.shift()`), a *stronger* guarantee than AWS actually provides — which hides an entire class of order-dependent bugs from local/CI/PRE testing.

## What

- **Standard-queue dequeue now picks a random ready message** instead of the head. This models AWS's "no ordering guarantee" and applies both to direct SQS receives and to messages fanned out from a standard SNS topic (they land in the standard `messages[]` array and are reordered at receive).
- **FIFO queues are unchanged** and remain the only way to get ordering — there is intentionally **no strict-ordering opt-out** (forcing strict order on a standard queue would replicate behaviour real AWS does not provide).
- **Seedable PRNG** (`mulberry32`) for determinism: `startFauxqs({ ordering: { seed } })` or `FAUXQS_ORDERING_SEED`. Same seed → same interleaving, for reproducible tests and failure replays. No seed → non-deterministic.

## Tests

- New `test/sqs/ordering.test.ts`: reorder occurs (seeded), seed reproducibility, FIFO unaffected, and SNS→SQS end-to-end reorder.
- Two `inspect` tests that assumed strict receive order were made order-independent (they assert message *state*, not ordering).
- Full suite (904 tests) green across repeated runs; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable message-ordering behavior for standard queues and topics, including an option to seed delivery order for repeatable local runs.
  * FIFO queues and topics continue to preserve strict ordering within each message group.

* **Documentation**
  * Updated guidance on how standard vs. FIFO ordering works, including how to enable deterministic ordering through configuration or environment settings.

* **Bug Fixes**
  * Standard-queue message inspection now reflects non-deterministic delivery order instead of assuming a fixed sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->