### PR TITLE
fix: allow supplementary-plane characters in SQS message bodies, matching AWS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { SqsStore } from "./sqs/sqsStore.ts";
 import type { MessageAttributeValue } from "./sqs/sqsTypes.ts";
 import {
   INVALID_MESSAGE_BODY_CHAR,
+  INVALID_MESSAGE_BODY_CHAR_MESSAGE,
   calculateMessageSize,
   parseOptionalMessageGroupId,
 } from "./sqs/sqsTypes.ts";
@@ -686,9 +687,7 @@ export async function startFauxqs(options?: {
 
       // Validate message body characters (same as SDK handler)
       if (INVALID_MESSAGE_BODY_CHAR.test(body)) {
-        throw new Error(
-          "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.",
-        );
+        throw new Error(INVALID_MESSAGE_BODY_CHAR_MESSAGE);
       }
 
       const messageAttributes = opts?.messageAttributes ?? {};

--- a/src/app.ts
+++ b/src/app.ts
@@ -687,7 +687,7 @@ export async function startFauxqs(options?: {
       // Validate message body characters (same as SDK handler)
       if (INVALID_MESSAGE_BODY_CHAR.test(body)) {
         throw new Error(
-          "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF and #xE000 to #xFFFD.",
+          "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.",
         );
       }
 

--- a/src/sqs/actions/sendMessage.ts
+++ b/src/sqs/actions/sendMessage.ts
@@ -29,7 +29,7 @@ export function sendMessage(body: Record<string, unknown>, store: SqsStore): Sen
   if (INVALID_MESSAGE_BODY_CHAR.test(messageBody)) {
     throw new SqsError(
       "InvalidMessageContents",
-      "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF and #xE000 to #xFFFD.",
+      "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.",
     );
   }
 

--- a/src/sqs/actions/sendMessage.ts
+++ b/src/sqs/actions/sendMessage.ts
@@ -6,6 +6,7 @@ import { SqsStore as SqsStoreClass } from "../sqsStore.ts";
 import type { MessageAttributeValue } from "../sqsTypes.ts";
 import {
   INVALID_MESSAGE_BODY_CHAR,
+  INVALID_MESSAGE_BODY_CHAR_MESSAGE,
   calculateMessageSize,
   parseOptionalMessageGroupId,
 } from "../sqsTypes.ts";
@@ -27,10 +28,7 @@ export function sendMessage(body: Record<string, unknown>, store: SqsStore): Sen
   }
 
   if (INVALID_MESSAGE_BODY_CHAR.test(messageBody)) {
-    throw new SqsError(
-      "InvalidMessageContents",
-      "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.",
-    );
+    throw new SqsError("InvalidMessageContents", INVALID_MESSAGE_BODY_CHAR_MESSAGE);
   }
 
   const messageAttributes = (body.MessageAttributes as Record<string, MessageAttributeValue>) ?? {};

--- a/src/sqs/actions/sendMessageBatch.ts
+++ b/src/sqs/actions/sendMessageBatch.ts
@@ -10,6 +10,7 @@ import { SqsStore as SqsStoreClass } from "../sqsStore.ts";
 import type { MessageAttributeValue } from "../sqsTypes.ts";
 import {
   INVALID_MESSAGE_BODY_CHAR,
+  INVALID_MESSAGE_BODY_CHAR_MESSAGE,
   SQS_MAX_MESSAGE_SIZE_BYTES,
   VALID_BATCH_ENTRY_ID,
   calculateMessageSize,
@@ -92,8 +93,7 @@ export function sendMessageBatch(
         Id: entry.Id,
         SenderFault: true,
         Code: "InvalidMessageContents",
-        Message:
-          "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.",
+        Message: INVALID_MESSAGE_BODY_CHAR_MESSAGE,
       });
       continue;
     }

--- a/src/sqs/actions/sendMessageBatch.ts
+++ b/src/sqs/actions/sendMessageBatch.ts
@@ -93,7 +93,7 @@ export function sendMessageBatch(
         SenderFault: true,
         Code: "InvalidMessageContents",
         Message:
-          "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF and #xE000 to #xFFFD.",
+          "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.",
       });
       continue;
     }

--- a/src/sqs/sqsTypes.ts
+++ b/src/sqs/sqsTypes.ts
@@ -126,6 +126,9 @@ export const INVALID_MESSAGE_BODY_CHAR =
   // eslint-disable-next-line no-control-regex
   /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/u;
 
+export const INVALID_MESSAGE_BODY_CHAR_MESSAGE =
+  "Invalid characters found. Valid unicode characters are #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF.";
+
 // Max message size: 1 MiB (1,048,576 bytes) for SQS
 export const SQS_MAX_MESSAGE_SIZE_BYTES = 1_048_576;
 

--- a/src/sqs/sqsTypes.ts
+++ b/src/sqs/sqsTypes.ts
@@ -117,9 +117,14 @@ export function parseOptionalMessageGroupId(
   return { ok: true, messageGroupId: raw };
 }
 
-// AWS SQS allowed unicode characters: #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD
-// eslint-disable-next-line no-control-regex
-export const INVALID_MESSAGE_BODY_CHAR = /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD]/;
+// AWS SQS allowed unicode characters:
+// #x9 | #xA | #xD | #x20 to #xD7FF | #xE000 to #xFFFD | #x10000 to #x10FFFF
+// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
+// The `u` flag makes the class operate on code points, so well-formed surrogate
+// pairs (emoji etc.) are allowed while lone surrogates are still rejected.
+export const INVALID_MESSAGE_BODY_CHAR =
+  // eslint-disable-next-line no-control-regex
+  /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/u;
 
 // Max message size: 1 MiB (1,048,576 bytes) for SQS
 export const SQS_MAX_MESSAGE_SIZE_BYTES = 1_048_576;

--- a/test/sqs/send-receive.test.ts
+++ b/test/sqs/send-receive.test.ts
@@ -293,6 +293,33 @@ describe("SQS Send/Receive/Delete", () => {
     expect(sent.MessageId).toBeDefined();
   });
 
+  it("accepts supplementary-plane characters (emoji), like AWS SQS does", async () => {
+    const body = "\u{1F527} What you’ll need \u{1F4A1}";
+    const sent = await sqs.send(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: body,
+      }),
+    );
+    expect(sent.MessageId).toBeDefined();
+
+    const received = await sqs.send(
+      new ReceiveMessageCommand({ QueueUrl: queueUrl, MaxNumberOfMessages: 1 }),
+    );
+    expect(received.Messages?.[0]?.Body).toBe(body);
+  });
+
+  it("rejects a lone surrogate", async () => {
+    await expect(
+      sqs.send(
+        new SendMessageCommand({
+          QueueUrl: queueUrl,
+          MessageBody: "broken \uD83D pair",
+        }),
+      ),
+    ).rejects.toThrow("Invalid characters");
+  });
+
   it("rejects message exceeding 1 MiB size limit", async () => {
     const largeBody = "x".repeat(1_048_577); // 1 byte over limit
     await expect(


### PR DESCRIPTION
 ## Problem

The `INVALID_MESSAGE_BODY_CHAR` rejects supplementary-plane characters (`#x10000` to `#x10FFFF`), which real AWS SQS explicitly allows ([see](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html)). Any message body containing an emoji fails with `InvalidMessageContents`, even though production SQS accepts it - making fauxqs stricter than the service it emulates and producing false failures in tests/local setups.

## Fix

- Extend the character class with `\u{10000}-\u{10FFFF}` and add the `u` flag so it operates on code points: well-formed surrogate pairs (emoji) pass, lone surrogates and `\uFFFE`/`\uFFFF` are still rejected, matching AWS's documented ranges exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SQS messages now support the full AWS-compatible Unicode range, including emoji and other supplementary characters.
  - Invalid lone surrogate characters continue to be rejected.

- **Tests**
  - Added coverage confirming supported Unicode characters are preserved through message send and receive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->