### PR TITLE
fix: trigger publish via pull_request_target so fork PRs can release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,15 @@
 ---
 name: publish
 
+# pull_request_target is used instead of pull_request because the release
+# steps push a version-bump commit and publish to npm, and on pull_request
+# events from forks the GITHUB_TOKEN is forced read-only (and id-token is
+# unavailable), which 403s the push. This is safe from the usual
+# pull_request_target pwn-request vector: the job only runs once the PR has
+# been merged by a maintainer, and it checks out and builds the base branch
+# (main), never the untrusted PR head.
 on:
-  pull_request:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - closed
     branches:


### PR DESCRIPTION
## Why

The v2.9.1 release for #278 failed: the publish workflow could not push the version-bump commit (`Permission to kibertoad/fauxqs.git denied to github-actions[bot]`, 403).

#278 was the first release-labeled PR opened from a fork. On `pull_request` events whose head is a fork, GitHub forces the `GITHUB_TOKEN` to read-only — the workflow-level `permissions: contents: write` cannot override that. All previous releases worked because their PRs came from branches in this repo.

## What

Switch the trigger to `pull_request_target`, which runs in the base-repo context with a normal write-capable token even for fork PRs.

This is safe from the usual `pull_request_target` pwn-request vector: the job only runs when `merged == true` (i.e. a maintainer already merged the code) and checks out/builds the base branch (`main`), never the untrusted PR head. An inline zizmor ignore for `dangerous-triggers` documents this.

Merging this PR (labeled `patch`) will itself trigger the publish workflow and release v2.9.1, which includes the stranded fix from #278.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to run after pull requests are merged into the main branch.
  * Added documentation clarifying workflow security constraints and rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->