### PR TITLE
fix: cut releases from pushes to main so fork PRs can publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,73 @@
 ---
 name: publish
 
-# pull_request_target is used instead of pull_request because the release
-# steps push a version-bump commit and publish to npm, and on pull_request
-# events from forks the GITHUB_TOKEN is forced read-only (and id-token is
-# unavailable), which 403s the push. This is safe from the usual
-# pull_request_target pwn-request vector: the job only runs once the PR has
-# been merged by a maintainer, and it checks out and builds the base branch
-# (main), never the untrusted PR head.
+# Releases are cut from pushes to main (i.e. a merged PR) rather than from the
+# pull_request event, because neither PR-based trigger can complete a release:
+#
+#   * on `pull_request` from a fork the GITHUB_TOKEN is forced read-only and
+#     id-token is unavailable, so pushing the version bump commit 403s;
+#   * on `pull_request_target` the push works, but npm's trusted publishing
+#     refuses to exchange the OIDC token for that event, so `pnpm publish`
+#     falls back to anonymous and 404s (see npm/cli#8739).
+#
+# The bump commit and tag below are pushed with GITHUB_TOKEN, which by design
+# does not re-trigger this workflow, so releases do not recurse.
 on:
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
-    types:
-      - closed
+  push:
     branches:
       - main
 
 permissions: {}
 
+# Serialize releases: two merges landing back to back must not race to bump
+# and publish the same version. `queue: max` retains the queued runs; the
+# default `queue: single` cancels a pending run as soon as a newer one
+# arrives, which would silently drop a release.
+concurrency:
+  group: publish
+  queue: max
+
 jobs:
+  # The push event carries no PR context, so the release labels have to be
+  # resolved from the pull request the pushed commit was merged from.
+  check:
+    name: Determine version bump
+    runs-on: ubuntu-latest
+    outputs:
+      bump: ${{ steps.version.outputs.bump }}
+
+    permissions:
+      contents: read # read the commit
+      pull-requests: read # read the merged PR's labels
+
+    steps:
+      - name: Resolve bump from merged PR labels
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          labels="$(gh api "repos/$REPOSITORY/commits/$SHA/pulls" \
+            --jq '.[] | select(.merged_at != null) | .labels[].name')"
+          echo "Labels on the merged PR: ${labels//$'\n'/, }"
+
+          if printf '%s\n' "$labels" | grep -Fxq major; then
+            bump=major
+          elif printf '%s\n' "$labels" | grep -Fxq minor; then
+            bump=minor
+          elif printf '%s\n' "$labels" | grep -Fxq patch; then
+            bump=patch
+          else
+            bump=
+            echo "No release label found, skipping release."
+          fi
+
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
   publish:
-    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
+    needs: check
+    if: needs.check.outputs.bump != ''
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.bump.outputs.tag }}
@@ -36,6 +84,11 @@ jobs:
       - name: Checkout Repository # zizmor: ignore[artipacked]
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Release the current tip of main rather than the pushed commit: a
+          # run queued behind another release would otherwise bump a
+          # package.json that the run ahead of it has already bumped, and
+          # collide on an existing tag.
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -63,17 +116,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Determine version bump
-        id: version
-        run: |
-          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
-            echo "bump=major" >> $GITHUB_OUTPUT
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-          else
-            echo "bump=patch" >> $GITHUB_OUTPUT
-          fi
-
       - name: Bump version
         id: bump
         run: |
@@ -82,7 +124,7 @@ jobs:
           git push
           git push --tags
         env:
-          VERSION_BUMP: ${{ steps.version.outputs.bump }}
+          VERSION_BUMP: ${{ needs.check.outputs.bump }}
 
       - name: Publish to npm
         run: pnpm publish --provenance --access public --no-git-checks


### PR DESCRIPTION
## Problem

Two consecutive releases failed, for two different reasons, and the second attempt left `v2.9.1` tagged on `main` but never published.

| Run | Trigger | Outcome |
|---|---|---|
| [32382909235](https://github.com/kibertoad/fauxqs/actions/runs/32382909235) (#278, fork PR) | `pull_request` | `git push` of the bump commit → **403** |
| [32385166206](https://github.com/kibertoad/fauxqs/actions/runs/32385166206) (#279) | `pull_request_target` | push OK, `pnpm publish` → **404** |

* On `pull_request` from a **fork**, `GITHUB_TOKEN` is forced read-only and `id-token` is unavailable, so the version bump commit cannot be pushed.
* Switching to `pull_request_target` (#279) fixed the push, but npm's trusted publishing refuses to exchange the OIDC token for that event:

  ```
  [WARN] Skipped OIDC: ERR_PNPM_AUTH_TOKEN_EXCHANGE: Failed token exchange request
         with body message: Unknown error (status code 404)
  [E404] 404 Not Found - PUT https://registry.npmjs.org/fauxqs - Not found
  ```

  `pnpm` then fell back to anonymous, and npm answers unauthenticated publishes with 404. There is no `NPM_TOKEN` secret in this repo, so OIDC is the only auth path — when it's skipped, publishing cannot succeed. Same failure, same trigger, reported upstream in [npm/cli#8739](https://github.com/npm/cli/issues/8739), where it also went away by moving to `push`.

## Fix

Trigger the release from **pushes to `main`**. A merge to `main` produces a push event with a full-permission `GITHUB_TOKEN` no matter where the PR came from, and npm accepts OIDC for it. The workflow filename stays `publish.yml`, so the npm trusted-publisher configuration keeps matching.

A push carries no PR context, so the `patch`/`minor`/`major` label is now resolved from the merged PR associated with the pushed commit (`repos/{repo}/commits/{sha}/pulls`) in a cheap `check` job; `publish` runs only if that job yields a bump.

Releases are serialized with a `concurrency` group using `queue: max` — the default `queue: single` cancels a pending run as soon as a newer one arrives, which would silently drop a release when two PRs merge back to back. For the same reason the release checks out the **tip of `main`** rather than the pushed SHA: a run queued behind another release would otherwise bump a `package.json` that the run ahead of it had already bumped, and collide on an existing tag.

The bump commit and tag are pushed with `GITHUB_TOKEN`, which by design does not trigger workflows, so releases do not recurse.

## Notes

* `v2.9.1` is tagged on `main` and `package.json` says `2.9.1`, but npm's latest is `2.9.0` and no Docker image was built for it. Its only content was the CI change in #279, so nothing user-facing is missing. With this PR labeled `patch`, the next release lands as **2.9.2** and `2.9.1` is simply skipped on npm. The orphan `v2.9.1` tag can be deleted separately if you'd rather not keep it.
* `queue: max` was validated empirically before adopting it: a throwaway workflow using that syntax was pushed to this branch, [ran green](https://github.com/kibertoad/fauxqs/actions/runs/32403279151), and was removed again.
* Merging this PR is itself the end-to-end test of the new pipeline.
