### PR TITLE
feat: run the server as an unprivileged user in Docker

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: Run Docker S3 file storage acceptance test
         run: pnpm test:docker:s3-storage
+
+      - name: Run Docker non-root acceptance test
+        run: pnpm test:docker:nonroot

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -106,7 +106,7 @@ Alternatively, use `forcePathStyle: true` on the S3 client if you prefer path-st
 
 ## Container User
 
-The server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root only to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host.
+The server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root only to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host. Directories that are already writable by that user keep their ownership — the handover only happens where it is needed.
 
 To avoid the root phase entirely, start the container as non-root — dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works:
 
@@ -114,7 +114,9 @@ To avoid the root phase entirely, start the container as non-root — dnsmasq ca
 docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTENCE=true kibertoad/fauxqs
 ```
 
-In that mode a bind-mounted directory must already be writable by the uid you pass.
+In that mode a bind-mounted directory must already be writable by the uid you pass; if it is not, the container reports which directory is at fault and refuses to start rather than failing every write at runtime.
+
+Wildcard DNS needs the `NET_BIND_SERVICE` capability wherever port 53 counts as privileged, which includes most Kubernetes clusters. If you drop all capabilities (`--cap-drop=ALL`, or Kubernetes' `restricted` policy), add that one back to keep it. Without it the container still starts and the API works — `*.fauxqs` names just won't resolve inside the container, so S3 clients need `forcePathStyle: true`.
 
 ## Persistence
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -101,6 +101,20 @@ Alternatively, use `forcePathStyle: true` on the S3 client if you prefer path-st
 | `FAUXQS_PERSISTENCE` | Enable SQLite persistence (requires a volume mounted at `/data`) | `false` |
 | `FAUXQS_DATA_DIR` | Directory for the SQLite database | `/data` (preset in image) |
 | `FAUXQS_S3_STORAGE_DIR` | Store S3 objects as files on disk instead of SQLite blobs | (none) |
+| `FAUXQS_RUN_USER` | User the server runs as — name, uid, or `uid:gid` | `node` (uid 1000) |
+| `FAUXQS_RUN_AS_ROOT` | Keep the server running as root instead of dropping privileges | `false` |
+
+## Container User
+
+The server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root only to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host.
+
+To avoid the root phase entirely, start the container as non-root — dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works:
+
+```bash
+docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTENCE=true kibertoad/fauxqs
+```
+
+In that mode a bind-mounted directory must already be writable by the uid you pass.
 
 ## Persistence
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -101,29 +101,29 @@ Alternatively, use `forcePathStyle: true` on the S3 client if you prefer path-st
 | `FAUXQS_PERSISTENCE` | Enable SQLite persistence (requires a volume mounted at `/data`) | `false` |
 | `FAUXQS_DATA_DIR` | Directory for the SQLite database | `/data` (preset in image) |
 | `FAUXQS_S3_STORAGE_DIR` | Store S3 objects as files on disk instead of SQLite blobs | (none) |
-| `FAUXQS_RUN_USER` | User the server runs as — name, uid, or `uid:gid` | `node` (uid 1000) |
+| `FAUXQS_RUN_USER` | User the server runs as (name, uid, or `uid:gid`) | `node` (uid 1000) |
 | `FAUXQS_RUN_AS_ROOT` | Keep the server running as root instead of dropping privileges | `false` |
 
 ## Container User
 
-By default the server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root only to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host. Directories that are already writable by that user keep their ownership — the handover only happens where it is needed.
+By default the server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host. Directories `node` can already write to keep their ownership; the handover only happens where it is needed.
 
-Non-root is the default, not a guarantee. Two supported cases keep the server as root, both of them logged:
+Two situations leave the server running as root, and both are visible in the log, so non-root is the default rather than a guarantee:
 
 - `FAUXQS_RUN_AS_ROOT=true`, which selects root deliberately.
-- A write directory that `chown` cannot hand over while root can still write to it — some remote filesystems ignore `chown`. The entrypoint prints `WARNING: Keeping the server as root, which can write to <dir>` and names the directory. If *neither* the unprivileged user nor root can write to it (a read-only mount), it refuses to start instead of failing on the first write.
+- A write directory that `chown` cannot hand over while root can still write to it. Some remote filesystems accept a `chown` without applying it; there the entrypoint logs `WARNING: Keeping the server as root, which can write to <dir>`. If neither the unprivileged user nor root can write to it, as on a read-only mount, the container names the directory and refuses to start instead of failing on its first write.
 
-To avoid the root phase entirely, start the container as non-root — dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works:
+To avoid the root phase entirely, start the container as non-root. dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works:
 
 ```bash
 docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTENCE=true kibertoad/fauxqs
 ```
 
-In that mode a bind-mounted directory must already be writable by the uid you pass; if it is not, the container reports which directory is at fault and refuses to start rather than failing every write at runtime.
+In that mode a bind-mounted directory must already be writable by the uid you pass. The container cannot fix the ownership itself, so it names the directory and refuses to start.
 
-Wildcard DNS needs the `NET_BIND_SERVICE` capability only where port 53 counts as privileged. Docker sets `net.ipv4.ip_unprivileged_port_start=0` by default, so it works there even under `--cap-drop=ALL`; most Kubernetes clusters leave port 53 privileged, so under the `restricted` policy add that one capability back to keep wildcard DNS. Where it is missing and the port is privileged, the container still starts and the API works normally — the log says wildcard DNS is unavailable.
+Wildcard DNS needs the `NET_BIND_SERVICE` capability only where port 53 counts as privileged. Docker sets `net.ipv4.ip_unprivileged_port_start=0` by default, so it keeps working there even under `--cap-drop=ALL`. Most Kubernetes clusters leave port 53 privileged, so under the `restricted` policy add that one capability back to keep wildcard DNS. Without it on a privileged-port runtime, dnsmasq does not start; the container and the API are unaffected, and the log says wildcard DNS is unavailable.
 
-That only affects clients resolving `<bucket>.s3.<container-hostname>` through the container's own DNS, i.e. other containers on the same network. Clients on the host using `*.localhost.fauxqs.dev` are unaffected, since that wildcard is public DNS. For an affected container client, point the endpoint at a name its own resolver can reach — the compose service name, e.g. `http://fauxqs:4566` — and set `forcePathStyle: true`; `forcePathStyle` alone does not change the endpoint host.
+The only clients that lose anything are the ones resolving `<bucket>.s3.<container-hostname>` through the container's own DNS, which means other containers on the same network. Clients on the host use the public `*.localhost.fauxqs.dev` wildcard, so they are unaffected. For a container client, give it an endpoint its own resolver can reach, such as the compose service name `http://fauxqs:4566`, and set `forcePathStyle: true`. Setting `forcePathStyle` on its own does not help, because it does not change the endpoint host.
 
 ## Persistence
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -106,7 +106,12 @@ Alternatively, use `forcePathStyle: true` on the S3 client if you prefer path-st
 
 ## Container User
 
-The server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root only to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host. Directories that are already writable by that user keep their ownership — the handover only happens where it is needed.
+By default the server runs as the unprivileged `node` user (uid 1000). The entrypoint starts as root only to bind dnsmasq to port 53 and to hand the mounted directories over to that user, so root-owned bind mounts like `-v ./volume:/data` keep working with nothing to prepare on the host. Directories that are already writable by that user keep their ownership — the handover only happens where it is needed.
+
+Non-root is the default, not a guarantee. Two supported cases keep the server as root, both of them logged:
+
+- `FAUXQS_RUN_AS_ROOT=true`, which selects root deliberately.
+- A write directory that `chown` cannot hand over while root can still write to it — some remote filesystems ignore `chown`. The entrypoint prints `WARNING: Keeping the server as root, which can write to <dir>` and names the directory. If *neither* the unprivileged user nor root can write to it (a read-only mount), it refuses to start instead of failing on the first write.
 
 To avoid the root phase entirely, start the container as non-root — dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works:
 
@@ -116,7 +121,9 @@ docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTE
 
 In that mode a bind-mounted directory must already be writable by the uid you pass; if it is not, the container reports which directory is at fault and refuses to start rather than failing every write at runtime.
 
-Wildcard DNS needs the `NET_BIND_SERVICE` capability wherever port 53 counts as privileged, which includes most Kubernetes clusters. If you drop all capabilities (`--cap-drop=ALL`, or Kubernetes' `restricted` policy), add that one back to keep it. Without it the container still starts and the API works — `*.fauxqs` names just won't resolve inside the container, so S3 clients need `forcePathStyle: true`.
+Wildcard DNS needs the `NET_BIND_SERVICE` capability only where port 53 counts as privileged. Docker sets `net.ipv4.ip_unprivileged_port_start=0` by default, so it works there even under `--cap-drop=ALL`; most Kubernetes clusters leave port 53 privileged, so under the `restricted` policy add that one capability back to keep wildcard DNS. Where it is missing and the port is privileged, the container still starts and the API works normally — the log says wildcard DNS is unavailable.
+
+That only affects clients resolving `<bucket>.s3.<container-hostname>` through the container's own DNS, i.e. other containers on the same network. Clients on the host using `*.localhost.fauxqs.dev` are unaffected, since that wildcard is public DNS. For an affected container client, point the endpoint at a name its own resolver can reach — the compose service name, e.g. `http://fauxqs:4566` — and set `forcePathStyle: true`; `forcePathStyle` alone does not change the endpoint host.
 
 ## Persistence
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@ RUN pnpm run build
 
 FROM node:24-alpine
 
-RUN apk add --no-cache tini dnsmasq
+# su-exec: drop privileges in the entrypoint after the root-only setup
+# libcap:  give dnsmasq the capability to bind port 53 without being root,
+#          so the image also works when started with --user / runAsUser
+RUN apk add --no-cache tini dnsmasq su-exec \
+  && apk add --no-cache --virtual .caps libcap \
+  && setcap cap_net_bind_service+ep /usr/sbin/dnsmasq \
+  && apk del .caps
 
 WORKDIR /app
 
@@ -25,6 +31,15 @@ RUN pnpm install --prod --frozen-lockfile
 COPY --from=build /app/dist/ dist/
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Pre-create the data directory owned by the unprivileged user so that empty
+# named volumes mounted here inherit that ownership from the image.
+RUN mkdir -p /data && chown node:node /data
+
+# No USER directive on purpose: the entrypoint needs root to bind dnsmasq to
+# port 53 and to take ownership of bind-mounted volumes, and drops to the
+# unprivileged `node` user before exec'ing the server. Start the container
+# with --user/runAsUser if you want no root phase at all.
 
 ENV FAUXQS_HOST=localhost
 ENV FAUXQS_DATA_DIR=/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,17 @@ FROM node:24-alpine
 
 # su-exec: drop privileges in the entrypoint after the root-only setup
 # libcap:  give dnsmasq the capability to bind port 53 without being root,
-#          so the image also works when started with --user / runAsUser
+#          so the image also works when started with --user / runAsUser.
+#
+# The effective bit in +ep is what actually delivers the capability, but it also
+# makes execve of dnsmasq fail with EPERM whenever NET_BIND_SERVICE is missing
+# from the bounding set — as it is under --cap-drop=ALL and Kubernetes'
+# restricted policy. dnsmasq-nocap is the same binary without the file
+# capability, which the entrypoint falls back to: it cannot ask for the
+# capability, but it does not need it wherever port 53 is unprivileged, which is
+# the default in Docker. Copy it before setcap so the copy stays uncapped.
 RUN apk add --no-cache tini dnsmasq su-exec \
+  && cp /usr/sbin/dnsmasq /usr/sbin/dnsmasq-nocap \
   && apk add --no-cache --virtual .caps libcap \
   && setcap cap_net_bind_service+ep /usr/sbin/dnsmasq \
   && apk del .caps

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ This keeps bind mounts working: `-v ./volume:/data` gives you a root-owned host 
 
 The handover only happens when it is needed. If the unprivileged user can already write to a directory, because you prepared it or because a previous run did, its ownership is left alone. So `chown -R` never touches host files that do not need it, and restart time does not grow with the number of stored objects.
 
-Two knobs, both for Docker only:
+Two environment variables, both Docker only:
 
 - **`FAUXQS_RUN_USER`** — run as a different user, e.g. `FAUXQS_RUN_USER=1001` or `FAUXQS_RUN_USER=501:20`. Useful when a host directory must keep a specific owner, so you'd rather match it than have it chowned. A value the server cannot run as is reported at startup; it does not quietly fall back to root.
-- **`FAUXQS_RUN_AS_ROOT=true`** — keep the server as root. An escape hatch for setups that need it; not recommended.
+- **`FAUXQS_RUN_AS_ROOT=true`** — keep the server as root. For setups that genuinely need it; not recommended.
 
 If you'd rather have no root phase at all, start the container as a non-root user:
 

--- a/README.md
+++ b/README.md
@@ -164,16 +164,16 @@ docker run -p 4566:4566 \
 
 #### Container user
 
-By default the server does not run as root. The entrypoint starts as root only to do what needs privileges — binding dnsmasq to port 53 and taking ownership of the mounted directories — and then drops to the unprivileged `node` user (uid 1000) before starting the server. Two cases keep it as root, both of them logged: `FAUXQS_RUN_AS_ROOT=true`, and a write directory that `chown` cannot hand over while root can still write to it (see the end of this section). Treat non-root as the default rather than an unconditional guarantee.
+By default the server does not run as root. The entrypoint starts as root to do the two things that need privileges: bind dnsmasq to port 53, and take ownership of the mounted directories. It then drops to the unprivileged `node` user (uid 1000) before starting the server.
 
 This keeps bind mounts working: `-v ./volume:/data` gives you a root-owned host directory, which the entrypoint hands over to `node` on startup. Nothing to prepare on the host.
 
-The handover only happens when it is needed. A directory the unprivileged user can already write to — because you prepared it, or because a previous run already did — is left with its ownership untouched, so `chown -R` never rewrites host files behind your back and restarts stay quick no matter how many objects are stored.
+The handover only happens when it is needed. If the unprivileged user can already write to a directory, because you prepared it or because a previous run did, its ownership is left alone. So `chown -R` never touches host files that do not need it, and restart time does not grow with the number of stored objects.
 
 Two knobs, both for Docker only:
 
-- `FAUXQS_RUN_USER` — run as a different user, e.g. `FAUXQS_RUN_USER=1001` or `FAUXQS_RUN_USER=501:20`. Useful when a host directory must keep a specific owner, so you'd rather match it than have it chowned. A value that cannot be used to run the server is reported at startup rather than quietly falling back to root.
-- `FAUXQS_RUN_AS_ROOT=true` — keep the server as root. An escape hatch for setups that need it; not recommended.
+- **`FAUXQS_RUN_USER`** — run as a different user, e.g. `FAUXQS_RUN_USER=1001` or `FAUXQS_RUN_USER=501:20`. Useful when a host directory must keep a specific owner, so you'd rather match it than have it chowned. A value the server cannot run as is reported at startup; it does not quietly fall back to root.
+- **`FAUXQS_RUN_AS_ROOT=true`** — keep the server as root. An escape hatch for setups that need it; not recommended.
 
 If you'd rather have no root phase at all, start the container as a non-root user:
 
@@ -181,9 +181,11 @@ If you'd rather have no root phase at all, start the container as a non-root use
 docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTENCE=true kibertoad/fauxqs
 ```
 
-dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works this way. With an *empty* named volume, Docker copies the image's ownership of `/data` (uid 1000), so persistence works out of the box. A bind-mounted host directory, on the other hand, has to be writable by the uid you pass — the container can no longer fix the ownership itself, so it reports the problem at startup instead of serving a healthy `/health` while every write fails.
+dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works this way. With an *empty* named volume, Docker copies the image's ownership of `/data` (uid 1000), so persistence works out of the box. A bind-mounted host directory has to be writable by the uid you pass, since the container can no longer fix the ownership itself.
 
-Wildcard DNS needs the `NET_BIND_SERVICE` capability only where port 53 counts as privileged. Docker sets `net.ipv4.ip_unprivileged_port_start=0` by default, so it keeps working there even under `--cap-drop=ALL`; most Kubernetes clusters leave port 53 privileged, so under the `restricted` Pod Security Standard, which drops every capability, add that one back:
+If a directory the server writes to cannot be made writable (a read-only mount, or any mount the entrypoint lacks the privileges to fix), it names the directory and refuses to start. A server that started anyway would fail on its first write. Some remote filesystems accept a `chown` without applying it while root can still write; there the server stays root and logs a warning. That case and `FAUXQS_RUN_AS_ROOT=true` are the two situations where it ends up as root, so non-root is the default rather than a guarantee. Both are visible in the log.
+
+Wildcard DNS needs the `NET_BIND_SERVICE` capability only where port 53 counts as privileged. Docker sets `net.ipv4.ip_unprivileged_port_start=0` by default, so it keeps working there even under `--cap-drop=ALL`. Most Kubernetes clusters leave port 53 privileged, so under the `restricted` Pod Security Standard, which drops every capability, add that one back:
 
 ```yaml
 securityContext:
@@ -194,11 +196,9 @@ securityContext:
     add: ["NET_BIND_SERVICE"]   # omit if you don't need wildcard DNS
 ```
 
-Where the capability is missing and port 53 is privileged, the container still starts and the API works normally — dnsmasq just doesn't come up, which the logs point out.
+Without the capability on a privileged-port runtime, dnsmasq does not start. The container and the API are unaffected, and the log says wildcard DNS is unavailable.
 
-That only affects clients that resolve `<bucket>.s3.<container-hostname>` through the container's own DNS, i.e. [other containers on the same network](#container-to-container-s3-virtual-hosted-style). Clients on the host using `*.localhost.fauxqs.dev` are unaffected, since that wildcard is public DNS. For an affected container client, point the endpoint at a name its own resolver can reach — the compose service name, e.g. `http://fauxqs:4566` — and set `forcePathStyle: true`; `forcePathStyle` alone does not change the endpoint host.
-
-If a directory the server writes to cannot be made writable at all — a read-only mount, most often — the entrypoint says which directory is at fault and refuses to start, because a server that starts anyway would fail on its first write. When `chown` is merely ineffective (some remote filesystems ignore it) but root can still write, it stays root instead, and says so.
+The only clients that lose anything are the ones resolving `<bucket>.s3.<container-hostname>` through the container's own DNS, which means [other containers on the same network](#container-to-container-s3-virtual-hosted-style). Clients on the host use the public `*.localhost.fauxqs.dev` wildcard, so they are unaffected. For a container client, give it an endpoint its own resolver can reach, such as the compose service name `http://fauxqs:4566`, and set `forcePathStyle: true`. Setting `forcePathStyle` on its own does not help, because it does not change the endpoint host.
 
 ### Running in Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ docker run -p 4566:4566 \
 
 #### Container user
 
-The server does not run as root. The entrypoint starts as root only to do what needs privileges — binding dnsmasq to port 53 and taking ownership of the mounted directories — and then drops to the unprivileged `node` user (uid 1000) before starting the server.
+By default the server does not run as root. The entrypoint starts as root only to do what needs privileges — binding dnsmasq to port 53 and taking ownership of the mounted directories — and then drops to the unprivileged `node` user (uid 1000) before starting the server. Two cases keep it as root, both of them logged: `FAUXQS_RUN_AS_ROOT=true`, and a write directory that `chown` cannot hand over while root can still write to it (see the end of this section). Treat non-root as the default rather than an unconditional guarantee.
 
 This keeps bind mounts working: `-v ./volume:/data` gives you a root-owned host directory, which the entrypoint hands over to `node` on startup. Nothing to prepare on the host.
 
@@ -183,7 +183,7 @@ docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTE
 
 dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works this way. With an *empty* named volume, Docker copies the image's ownership of `/data` (uid 1000), so persistence works out of the box. A bind-mounted host directory, on the other hand, has to be writable by the uid you pass — the container can no longer fix the ownership itself, so it reports the problem at startup instead of serving a healthy `/health` while every write fails.
 
-Wildcard DNS needs the `NET_BIND_SERVICE` capability wherever port 53 counts as privileged, which includes most Kubernetes clusters. Under Kubernetes' `restricted` Pod Security Standard, which drops every capability, add it back:
+Wildcard DNS needs the `NET_BIND_SERVICE` capability only where port 53 counts as privileged. Docker sets `net.ipv4.ip_unprivileged_port_start=0` by default, so it keeps working there even under `--cap-drop=ALL`; most Kubernetes clusters leave port 53 privileged, so under the `restricted` Pod Security Standard, which drops every capability, add that one back:
 
 ```yaml
 securityContext:
@@ -194,7 +194,9 @@ securityContext:
     add: ["NET_BIND_SERVICE"]   # omit if you don't need wildcard DNS
 ```
 
-Without it the container still starts and the API works normally — `*.fauxqs` names just won't resolve inside the container, which the logs point out, and S3 clients need `forcePathStyle: true`.
+Where the capability is missing and port 53 is privileged, the container still starts and the API works normally — dnsmasq just doesn't come up, which the logs point out.
+
+That only affects clients that resolve `<bucket>.s3.<container-hostname>` through the container's own DNS, i.e. [other containers on the same network](#container-to-container-s3-virtual-hosted-style). Clients on the host using `*.localhost.fauxqs.dev` are unaffected, since that wildcard is public DNS. For an affected container client, point the endpoint at a name its own resolver can reach — the compose service name, e.g. `http://fauxqs:4566` — and set `forcePathStyle: true`; `forcePathStyle` alone does not change the endpoint host.
 
 If a directory the server writes to cannot be made writable at all — a read-only mount, most often — the entrypoint says which directory is at fault and refuses to start, because a server that starts anyway would fail on its first write. When `chown` is merely ineffective (some remote filesystems ignore it) but root can still write, it stays root instead, and says so.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ All state is in-memory by default. Optional SQLite-based persistence is availabl
   - [Running the server](#running-the-server)
   - [Running in the background](#running-in-the-background)
   - [Running with Docker](#running-with-docker)
+    - [Container user](#container-user)
   - [Running in Docker Compose](#running-in-docker-compose)
     - [Container-to-container S3 virtual-hosted-style](#container-to-container-s3-virtual-hosted-style)
   - [Configuring AWS SDK clients](#configuring-aws-sdk-clients)
@@ -96,6 +97,8 @@ The server starts on port `4566` and handles SQS, SNS, and S3 on a single endpoi
 | `FAUXQS_ORDERING_SEED` | Seed for the standard-queue reordering PRNG, for deterministic delivery order (see [Message ordering](#message-ordering)). Omit for non-deterministic ordering. | (none) |
 | `FAUXQS_DNS_NAME` | Domain that dnsmasq resolves (including all subdomains) to the container IP. Only needed when the container hostname doesn't match the docker-compose service name — e.g., when using `container_name` or running with plain `docker run`. In docker-compose the hostname is set to the service name automatically, so this is rarely needed. (Docker only) | container hostname |
 | `FAUXQS_DNS_UPSTREAM` | Where dnsmasq forwards non-fauxqs DNS queries (e.g., `registry.npmjs.org`). Change this if you're in a corporate network with an internal DNS server, or if you prefer a different public resolver like `1.1.1.1`. (Docker only) | `8.8.8.8` |
+| `FAUXQS_RUN_USER` | User the server process runs as (see [Container user](#container-user)). Accepts a name, a uid, or `uid:gid`. (Docker only) | `node` (uid 1000) |
+| `FAUXQS_RUN_AS_ROOT` | Set to `true` to keep the server running as root instead of dropping privileges (see [Container user](#container-user)). (Docker only) | `false` |
 
 ```bash
 FAUXQS_PORT=3000 FAUXQS_INIT=init.json npx fauxqs
@@ -158,6 +161,27 @@ docker run -p 4566:4566 \
   -e FAUXQS_INIT=/app/init.json \
   kibertoad/fauxqs
 ```
+
+#### Container user
+
+The server does not run as root. The entrypoint starts as root only to do what needs privileges — binding dnsmasq to port 53 and taking ownership of the mounted directories — and then drops to the unprivileged `node` user (uid 1000) before starting the server.
+
+This keeps bind mounts working: `-v ./volume:/data` gives you a root-owned host directory, which the entrypoint hands over to `node` on startup. Nothing to prepare on the host.
+
+Two knobs, both for Docker only:
+
+- `FAUXQS_RUN_USER` — run as a different user, e.g. `FAUXQS_RUN_USER=1001` or `FAUXQS_RUN_USER=501:20`. Useful when a host directory must keep a specific owner, so you'd rather match it than have it chowned.
+- `FAUXQS_RUN_AS_ROOT=true` — keep the server as root. An escape hatch for setups that need it; not recommended.
+
+If you'd rather have no root phase at all, start the container as a non-root user:
+
+```bash
+docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTENCE=true kibertoad/fauxqs
+```
+
+dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works this way. With an *empty* named volume, Docker copies the image's ownership of `/data` (uid 1000), so persistence works out of the box. A bind-mounted host directory, on the other hand, has to be writable by the uid you pass — the container can no longer fix the ownership itself.
+
+If a directory the server writes to cannot be made writable (a read-only mount, or a filesystem that ignores `chown`), the entrypoint logs a warning explaining which directory is at fault and stays root rather than starting into a broken state.
 
 ### Running in Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ The server does not run as root. The entrypoint starts as root only to do what n
 
 This keeps bind mounts working: `-v ./volume:/data` gives you a root-owned host directory, which the entrypoint hands over to `node` on startup. Nothing to prepare on the host.
 
+The handover only happens when it is needed. A directory the unprivileged user can already write to — because you prepared it, or because a previous run already did — is left with its ownership untouched, so `chown -R` never rewrites host files behind your back and restarts stay quick no matter how many objects are stored.
+
 Two knobs, both for Docker only:
 
-- `FAUXQS_RUN_USER` — run as a different user, e.g. `FAUXQS_RUN_USER=1001` or `FAUXQS_RUN_USER=501:20`. Useful when a host directory must keep a specific owner, so you'd rather match it than have it chowned.
+- `FAUXQS_RUN_USER` — run as a different user, e.g. `FAUXQS_RUN_USER=1001` or `FAUXQS_RUN_USER=501:20`. Useful when a host directory must keep a specific owner, so you'd rather match it than have it chowned. A value that cannot be used to run the server is reported at startup rather than quietly falling back to root.
 - `FAUXQS_RUN_AS_ROOT=true` — keep the server as root. An escape hatch for setups that need it; not recommended.
 
 If you'd rather have no root phase at all, start the container as a non-root user:
@@ -179,9 +181,22 @@ If you'd rather have no root phase at all, start the container as a non-root use
 docker run -p 4566:4566 --user 1000:1000 -v fauxqs-data:/data -e FAUXQS_PERSISTENCE=true kibertoad/fauxqs
 ```
 
-dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works this way. With an *empty* named volume, Docker copies the image's ownership of `/data` (uid 1000), so persistence works out of the box. A bind-mounted host directory, on the other hand, has to be writable by the uid you pass — the container can no longer fix the ownership itself.
+dnsmasq carries `cap_net_bind_service` as a file capability, so wildcard DNS still works this way. With an *empty* named volume, Docker copies the image's ownership of `/data` (uid 1000), so persistence works out of the box. A bind-mounted host directory, on the other hand, has to be writable by the uid you pass — the container can no longer fix the ownership itself, so it reports the problem at startup instead of serving a healthy `/health` while every write fails.
 
-If a directory the server writes to cannot be made writable (a read-only mount, or a filesystem that ignores `chown`), the entrypoint logs a warning explaining which directory is at fault and stays root rather than starting into a broken state.
+Wildcard DNS needs the `NET_BIND_SERVICE` capability wherever port 53 counts as privileged, which includes most Kubernetes clusters. Under Kubernetes' `restricted` Pod Security Standard, which drops every capability, add it back:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop: ["ALL"]
+    add: ["NET_BIND_SERVICE"]   # omit if you don't need wildcard DNS
+```
+
+Without it the container still starts and the API works normally — `*.fauxqs` names just won't resolve inside the container, which the logs point out, and S3 clients need `forcePathStyle: true`.
+
+If a directory the server writes to cannot be made writable at all — a read-only mount, most often — the entrypoint says which directory is at fault and refuses to start, because a server that starts anyway would fail on its first write. When `chown` is merely ineffective (some remote filesystems ignore it) but root can still write, it stays root instead, and says so.
 
 ### Running in Docker Compose
 

--- a/docker-acceptance/docker-acceptance.ts
+++ b/docker-acceptance/docker-acceptance.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert";
-import { execSync } from "node:child_process";
 import {
   S3Client,
   CreateBucketCommand,
   PutObjectCommand,
   GetObjectCommand,
 } from "@aws-sdk/client-s3";
+import { pollHealth, run } from "./dockerTestUtils.ts";
 
 const CONTAINER_NAME = `fauxqs-acceptance-${Date.now()}`;
 const HOST_PORT = 14566;
@@ -13,33 +13,6 @@ const ENDPOINT = `http://s3.localhost.fauxqs.dev:${HOST_PORT}`;
 const BUCKET = "test-bucket";
 const KEY = "hello.txt";
 const BODY = "Hello from Docker acceptance test!";
-
-function run(cmd: string): string {
-  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-}
-
-async function pollHealth(timeoutMs = 30_000): Promise<void> {
-  const start = Date.now();
-  // Use plain localhost for health check — no wildcard DNS dependency
-  const url = `http://localhost:${HOST_PORT}/health`;
-  let lastError: unknown;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-      lastError = new Error(`Health check returned ${res.status}`);
-    } catch (err) {
-      lastError = err;
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  // Dump container logs for debugging
-  try {
-    const logs = run(`docker logs ${CONTAINER_NAME}`);
-    console.error("Container logs:\n" + logs);
-  } catch { /* container may be gone */ }
-  throw new Error(`Health check timed out after ${timeoutMs}ms (last error: ${lastError})`);
-}
 
 async function main() {
   console.log("Building Docker image...");
@@ -51,7 +24,7 @@ async function main() {
   );
 
   console.log("Waiting for health check...");
-  await pollHealth();
+  await pollHealth(HOST_PORT, CONTAINER_NAME);
   console.log("Server is healthy.");
 
   // S3 client with virtual-hosted-style (no forcePathStyle)

--- a/docker-acceptance/docker-nonroot-acceptance.ts
+++ b/docker-acceptance/docker-nonroot-acceptance.ts
@@ -1,0 +1,502 @@
+import * as assert from "node:assert";
+import { execSync } from "node:child_process";
+import { chmodSync, mkdtempSync, writeFileSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  SQSClient,
+  CreateQueueCommand,
+  GetQueueUrlCommand,
+  SendMessageCommand,
+  ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  S3Client,
+  CreateBucketCommand,
+  PutObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
+
+/**
+ * Verifies that the Docker image runs the server as an unprivileged user, and
+ * that dropping privileges does not break the mount layouts people actually use
+ * (root-owned bind mounts, named volumes, read-only mounts, custom --user).
+ */
+
+const IMAGE = process.env.FAUXQS_TEST_IMAGE ?? "fauxqs-nonroot-test";
+const STAMP = Date.now();
+const HOST_PORT = 14569;
+const NODE_UID = 1000;
+
+const CONTAINERS: string[] = [];
+const VOLUMES: string[] = [];
+const TMP_DIRS: string[] = [];
+
+function run(cmd: string): string {
+  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+}
+
+function container(name: string): string {
+  const full = `fauxqs-nonroot-${name}-${STAMP}`;
+  CONTAINERS.push(full);
+  return full;
+}
+
+function volume(name: string): string {
+  const full = `fauxqs-nonroot-${name}-${STAMP}`;
+  VOLUMES.push(full);
+  run(`docker volume create ${full}`);
+  return full;
+}
+
+function hostDir(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `fauxqs-nonroot-${name}-`));
+  // The entrypoint chowns bind-mounted directories to the unprivileged user, so
+  // keep the mode permissive enough for this process to still inspect it after.
+  chmodSync(dir, 0o777);
+  TMP_DIRS.push(dir);
+  return dir;
+}
+
+function getLogs(name: string): string {
+  try {
+    return run(`docker logs ${name} 2>&1`);
+  } catch {
+    return "(could not retrieve logs)";
+  }
+}
+
+async function pollHealth(port: number, name: string, timeoutMs = 30_000): Promise<void> {
+  const start = Date.now();
+  const url = `http://localhost:${port}/health`;
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+      lastError = new Error(`Health check returned ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  console.error("Container logs:\n" + getLogs(name));
+  throw new Error(`Health check timed out after ${timeoutMs}ms (last error: ${lastError})`);
+}
+
+async function waitForExit(name: string, timeoutMs = 30_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const state = run(`docker inspect -f "{{.State.Running}}" ${name}`);
+    if (state === "false") return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Container ${name} was still running after ${timeoutMs}ms`);
+}
+
+/**
+ * PID 1 is always tini, exec'd as the user the server runs as (su-exec runs
+ * before tini), so its uid is the server's effective uid.
+ */
+function serverUid(name: string): number {
+  const status = run(`docker exec ${name} cat /proc/1/status`);
+  const line = status.split("\n").find((l) => l.startsWith("Uid:"));
+  assert.ok(line, `No Uid line in /proc/1/status:\n${status}`);
+  const uid = Number(line.trim().split(/\s+/)[1]);
+  assert.ok(Number.isInteger(uid), `Could not parse uid from "${line}"`);
+  return uid;
+}
+
+/** Owner name of the process actually running the server, as reported by ps. */
+function serverProcessOwner(name: string): string {
+  const ps = run(`docker exec ${name} ps -o user,args`);
+  const line = ps
+    .split("\n")
+    .find((l) => l.includes("node dist/server.js") && !l.includes("tini"));
+  assert.ok(line, `Server process not found in ps output:\n${ps}`);
+  return line.trim().split(/\s+/)[0]!;
+}
+
+function assertNonRoot(name: string, expectedUid = NODE_UID): void {
+  const uid = serverUid(name);
+  assert.strictEqual(uid, expectedUid, `Expected server to run as uid ${expectedUid}, got ${uid}`);
+  const owner = serverProcessOwner(name);
+  assert.notStrictEqual(owner, "root", `Server process is owned by root: ${owner}`);
+  console.log(`  Server runs as uid ${uid} (${owner}): OK`);
+}
+
+/** Numeric owner uid of each entry in a container directory. */
+function dirOwnerUids(name: string, dir: string): number[] {
+  const listing = run(`docker exec ${name} ls -ln ${dir}`);
+  return listing
+    .split("\n")
+    .filter((l) => /^[-d]/.test(l))
+    .map((l) => Number(l.trim().split(/\s+/)[2]));
+}
+
+/** Makes a volume look like a root-owned host bind mount. */
+function seedRootOwnedVolume(vol: string, mountPath: string): void {
+  run(
+    `docker run --rm --user 0:0 --entrypoint sh -v ${vol}:${mountPath} ${IMAGE} ` +
+      `-c "touch ${mountPath}/.keep && chown -R root:root ${mountPath} && chmod 755 ${mountPath}"`,
+  );
+}
+
+function makeSqsClient(port: number): SQSClient {
+  return new SQSClient({
+    endpoint: `http://localhost:${port}`,
+    region: "us-east-1",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  });
+}
+
+function makeS3Client(port: number): S3Client {
+  return new S3Client({
+    endpoint: `http://localhost:${port}`,
+    region: "us-east-1",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    forcePathStyle: true,
+  });
+}
+
+function banner(title: string): void {
+  console.log("\n══════════════════════════════════════");
+  console.log(`  ${title}`);
+  console.log("══════════════════════════════════════\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 1: default run — unprivileged server, working DNS and API
+// ─────────────────────────────────────────────────────────────────────────────
+async function testDefaultRun(): Promise<void> {
+  banner("Scenario 1: default run drops privileges");
+
+  const name = container("default");
+  const hostname = "fauxqs-default";
+  run(`docker run -d --name ${name} --hostname ${hostname} -p ${HOST_PORT}:4566 ${IMAGE}`);
+  await pollHealth(HOST_PORT, name);
+
+  const logs = getLogs(name);
+  assert.ok(
+    logs.includes("Server user: node"),
+    `Expected "Server user: node" in logs.\nLogs:\n${logs}`,
+  );
+  assertNonRoot(name);
+
+  // dnsmasq still owns port 53 after the drop (it is started while still root).
+  const dns = run(`docker exec ${name} nslookup my-bucket.s3.${hostname} 127.0.0.1`);
+  assert.ok(
+    dns.includes(`my-bucket.s3.${hostname}`),
+    `Wildcard DNS did not resolve after dropping privileges:\n${dns}`,
+  );
+  console.log("  Wildcard DNS resolves: OK");
+
+  // The API works end to end as the unprivileged user.
+  const s3 = makeS3Client(HOST_PORT);
+  await s3.send(new CreateBucketCommand({ Bucket: "nonroot-bucket" }));
+  await s3.send(
+    new PutObjectCommand({ Bucket: "nonroot-bucket", Key: "k.txt", Body: "unprivileged" }),
+  );
+  const got = await s3.send(new GetObjectCommand({ Bucket: "nonroot-bucket", Key: "k.txt" }));
+  assert.strictEqual(await got.Body!.transformToString(), "unprivileged");
+  console.log("  S3 put/get as unprivileged user: OK");
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 1 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 2: root-owned data mount (the `-v ./volume:/data` case)
+// ─────────────────────────────────────────────────────────────────────────────
+async function testRootOwnedDataMount(): Promise<void> {
+  banner("Scenario 2: root-owned data mount + persistence");
+
+  const vol = volume("rootvol");
+  seedRootOwnedVolume(vol, "/data");
+
+  const first = container("rootvol-1");
+  run(
+    `docker run -d --name ${first} -p ${HOST_PORT}:4566 ` +
+      `-e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, first);
+  console.log("  Container with root-owned /data is healthy: OK");
+  assertNonRoot(first);
+
+  const sqs = makeSqsClient(HOST_PORT);
+  const s3 = makeS3Client(HOST_PORT);
+  const queue = await sqs.send(new CreateQueueCommand({ QueueName: "nonroot-q" }));
+  await sqs.send(
+    new SendMessageCommand({ QueueUrl: queue.QueueUrl!, MessageBody: "survive-restart" }),
+  );
+  await s3.send(new CreateBucketCommand({ Bucket: "nonroot-persist" }));
+  await s3.send(
+    new PutObjectCommand({ Bucket: "nonroot-persist", Key: "o.txt", Body: "persisted" }),
+  );
+
+  // The database files must belong to the unprivileged user, not root.
+  const uids = dirOwnerUids(first, "/data");
+  assert.ok(
+    uids.length > 0 && uids.every((uid) => uid === NODE_UID),
+    `Expected every file in /data to be owned by uid ${NODE_UID}, got ${JSON.stringify(uids)}`,
+  );
+  console.log(`  /data contents owned by uid ${NODE_UID}: OK`);
+
+  run(`docker stop ${first}`);
+  run(`docker rm -f ${first}`);
+
+  const second = container("rootvol-2");
+  run(
+    `docker run -d --name ${second} -p ${HOST_PORT}:4566 ` +
+      `-e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, second);
+  assertNonRoot(second);
+
+  const sqs2 = makeSqsClient(HOST_PORT);
+  const s32 = makeS3Client(HOST_PORT);
+  const restored = await sqs2.send(new GetQueueUrlCommand({ QueueName: "nonroot-q" }));
+  const received = await sqs2.send(
+    new ReceiveMessageCommand({ QueueUrl: restored.QueueUrl!, MaxNumberOfMessages: 1 }),
+  );
+  assert.strictEqual(received.Messages?.[0]?.Body, "survive-restart", "SQS message did not survive");
+  const object = await s32.send(
+    new GetObjectCommand({ Bucket: "nonroot-persist", Key: "o.txt" }),
+  );
+  assert.strictEqual(await object.Body!.transformToString(), "persisted", "S3 object did not survive");
+  console.log("  State survived restart: OK");
+
+  run(`docker rm -f ${second}`);
+  console.log("\nScenario 2 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 3: host bind mount + mounted init config
+// ─────────────────────────────────────────────────────────────────────────────
+async function testHostBindMount(): Promise<void> {
+  banner("Scenario 3: host bind mount + mounted init config");
+
+  const dataDir = hostDir("data");
+  const initDir = hostDir("init");
+  const initFile = join(initDir, "init.json");
+  writeFileSync(initFile, JSON.stringify({ queues: [{ name: "from-init" }] }));
+
+  const name = container("bindmount");
+  run(
+    `docker run -d --name ${name} -p ${HOST_PORT}:4566 ` +
+      `-e FAUXQS_PERSISTENCE=true -e FAUXQS_INIT=/app/init.json ` +
+      `-v "${dataDir}":/data -v "${initFile}":/app/init.json:ro ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, name);
+  assertNonRoot(name);
+
+  // A read-only, root-owned init file must still be readable after the drop.
+  const sqs = makeSqsClient(HOST_PORT);
+  const fromInit = await sqs.send(new GetQueueUrlCommand({ QueueName: "from-init" }));
+  assert.ok(fromInit.QueueUrl, "Queue from the mounted init config was not created");
+  console.log("  Mounted read-only init config was applied: OK");
+
+  await sqs.send(new SendMessageCommand({ QueueUrl: fromInit.QueueUrl!, MessageBody: "hello" }));
+
+  // Persistence actually landed on the host directory.
+  const hostFiles = readdirSync(dataDir);
+  assert.ok(
+    hostFiles.some((f) => f.startsWith("fauxqs.db")),
+    `Expected a SQLite database in the bind-mounted host directory, saw: ${hostFiles.join(", ")}`,
+  );
+  console.log(`  Database written to host bind mount (${hostFiles.join(", ")}): OK`);
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 3 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 4: container started as non-root (docker run --user / runAsUser)
+// ─────────────────────────────────────────────────────────────────────────────
+async function testStartedAsNonRoot(): Promise<void> {
+  banner("Scenario 4: container started with --user (no root phase)");
+
+  const vol = volume("useropt");
+  const name = container("useropt");
+  const hostname = "fauxqs-useropt";
+  run(
+    `docker run -d --name ${name} --hostname ${hostname} --user ${NODE_UID}:${NODE_UID} ` +
+      `-p ${HOST_PORT}:4566 -e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, name);
+
+  const logs = getLogs(name);
+  assert.ok(
+    logs.includes("container started as non-root"),
+    `Expected the non-root startup path in logs.\nLogs:\n${logs}`,
+  );
+  assertNonRoot(name);
+
+  // Proves dnsmasq's file capability: binding port 53 without ever being root.
+  const dns = run(`docker exec ${name} nslookup b.s3.${hostname} 127.0.0.1`);
+  assert.ok(dns.includes(`b.s3.${hostname}`), `Wildcard DNS did not resolve:\n${dns}`);
+  console.log("  dnsmasq bound port 53 without root: OK");
+
+  // An empty named volume inherits /data's ownership from the image, so
+  // persistence works even though the entrypoint could not chown anything.
+  const sqs = makeSqsClient(HOST_PORT);
+  const queue = await sqs.send(new CreateQueueCommand({ QueueName: "useropt-q" }));
+  await sqs.send(new SendMessageCommand({ QueueUrl: queue.QueueUrl!, MessageBody: "keep" }));
+  run(`docker stop ${name}`);
+  run(`docker rm -f ${name}`);
+
+  const second = container("useropt-2");
+  run(
+    `docker run -d --name ${second} --user ${NODE_UID}:${NODE_UID} ` +
+      `-p ${HOST_PORT}:4566 -e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, second);
+  const sqs2 = makeSqsClient(HOST_PORT);
+  const restored = await sqs2.send(new GetQueueUrlCommand({ QueueName: "useropt-q" }));
+  const received = await sqs2.send(
+    new ReceiveMessageCommand({ QueueUrl: restored.QueueUrl!, MaxNumberOfMessages: 1 }),
+  );
+  assert.strictEqual(received.Messages?.[0]?.Body, "keep", "SQS message did not survive restart");
+  console.log("  Persistence works under --user: OK");
+
+  run(`docker rm -f ${second}`);
+  console.log("\nScenario 4 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 5: FAUXQS_RUN_USER selects a different unprivileged user
+// ─────────────────────────────────────────────────────────────────────────────
+async function testCustomRunUser(): Promise<void> {
+  banner("Scenario 5: FAUXQS_RUN_USER=1001 on a root-owned mount");
+
+  const vol = volume("customuser");
+  seedRootOwnedVolume(vol, "/data");
+
+  const name = container("customuser");
+  run(
+    `docker run -d --name ${name} -p ${HOST_PORT}:4566 -e FAUXQS_RUN_USER=1001 ` +
+      `-e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, name);
+  assertNonRoot(name, 1001);
+
+  const uids = dirOwnerUids(name, "/data");
+  assert.ok(
+    uids.length > 0 && uids.every((uid) => uid === 1001),
+    `Expected /data to be handed to uid 1001, got ${JSON.stringify(uids)}`,
+  );
+
+  const sqs = makeSqsClient(HOST_PORT);
+  const queue = await sqs.send(new CreateQueueCommand({ QueueName: "custom-user-q" }));
+  await sqs.send(new SendMessageCommand({ QueueUrl: queue.QueueUrl!, MessageBody: "written" }));
+  console.log("  Writes to the chowned volume as uid 1001: OK");
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 5 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 6: FAUXQS_RUN_AS_ROOT opts back into the old behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+async function testRunAsRootOptIn(): Promise<void> {
+  banner("Scenario 6: FAUXQS_RUN_AS_ROOT=true escape hatch");
+
+  const name = container("asroot");
+  run(
+    `docker run -d --name ${name} -p ${HOST_PORT}:4566 -e FAUXQS_RUN_AS_ROOT=true ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, name);
+
+  const logs = getLogs(name);
+  assert.ok(
+    logs.includes("Server user: root (FAUXQS_RUN_AS_ROOT=true)"),
+    `Expected the opt-in root message in logs.\nLogs:\n${logs}`,
+  );
+  assert.strictEqual(serverUid(name), 0, "Expected the server to run as root");
+  console.log("  Server runs as root on request: OK");
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 6 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 7: unwritable write directory keeps privileges and says why
+// ─────────────────────────────────────────────────────────────────────────────
+async function testUnwritableDirFallback(): Promise<void> {
+  banner("Scenario 7: read-only mount falls back to root with a diagnostic");
+
+  const vol = volume("readonly");
+  seedRootOwnedVolume(vol, "/s3data");
+
+  const name = container("readonly");
+  run(
+    `docker run -d --name ${name} -p ${HOST_PORT}:4566 ` +
+      `-e FAUXQS_S3_STORAGE_DIR=/s3data -v ${vol}:/s3data:ro ${IMAGE}`,
+  );
+
+  // chown cannot fix a read-only mount, so the entrypoint must not drop into a
+  // broken state — it explains the problem and stays root.
+  await waitForExit(name);
+  const logs = getLogs(name);
+  assert.ok(
+    logs.includes("WARNING: /s3data is not writable by 'node' and could not be chowned."),
+    `Expected the unwritable-directory warning in logs.\nLogs:\n${logs}`,
+  );
+  assert.ok(
+    logs.includes("Server user: root (fallback: /s3data not writable by 'node')"),
+    `Expected the root fallback message in logs.\nLogs:\n${logs}`,
+  );
+  console.log("  Warned about the unwritable mount and kept privileges: OK");
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 7 PASSED");
+}
+
+async function main(): Promise<void> {
+  if (!process.env.FAUXQS_TEST_IMAGE) {
+    console.log("Building Docker image...");
+    run(`docker build -t ${IMAGE} .`);
+  }
+
+  await testDefaultRun();
+  await testRootOwnedDataMount();
+  await testHostBindMount();
+  await testStartedAsNonRoot();
+  await testCustomRunUser();
+  await testRunAsRootOptIn();
+  await testUnwritableDirFallback();
+
+  console.log("\n══════════════════════════════════════");
+  console.log("  All non-root acceptance tests passed!");
+  console.log("══════════════════════════════════════\n");
+}
+
+main()
+  .catch((err) => {
+    console.error("\nNon-root acceptance test FAILED:", err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    console.log("Cleaning up...");
+    for (const name of CONTAINERS) {
+      try {
+        run(`docker rm -f ${name}`);
+      } catch {
+        /* already gone */
+      }
+    }
+    for (const vol of VOLUMES) {
+      try {
+        run(`docker volume rm -f ${vol}`);
+      } catch {
+        /* already gone */
+      }
+    }
+    for (const dir of TMP_DIRS) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort — root-owned leftovers are possible */
+      }
+    }
+  });

--- a/docker-acceptance/docker-nonroot-acceptance.ts
+++ b/docker-acceptance/docker-nonroot-acceptance.ts
@@ -1,21 +1,19 @@
 import * as assert from "node:assert";
-import { execSync } from "node:child_process";
 import { chmodSync, mkdtempSync, writeFileSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  SQSClient,
   CreateQueueCommand,
   GetQueueUrlCommand,
   SendMessageCommand,
   ReceiveMessageCommand,
 } from "@aws-sdk/client-sqs";
 import {
-  S3Client,
   CreateBucketCommand,
   PutObjectCommand,
   GetObjectCommand,
 } from "@aws-sdk/client-s3";
+import { getLogs, makeS3Client, makeSqsClient, pollHealth, run } from "./dockerTestUtils.ts";
 
 /**
  * Verifies that the Docker image runs the server as an unprivileged user, and
@@ -32,10 +30,6 @@ const CONTAINERS: string[] = [];
 const VOLUMES: string[] = [];
 const TMP_DIRS: string[] = [];
 
-function run(cmd: string): string {
-  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-}
-
 function container(name: string): string {
   const full = `fauxqs-nonroot-${name}-${STAMP}`;
   CONTAINERS.push(full);
@@ -51,47 +45,48 @@ function volume(name: string): string {
 
 function hostDir(name: string): string {
   const dir = mkdtempSync(join(tmpdir(), `fauxqs-nonroot-${name}-`));
-  // The entrypoint chowns bind-mounted directories to the unprivileged user, so
-  // keep the mode permissive enough for this process to still inspect it after.
+  // World-writable, so the unprivileged user can write to it without the
+  // entrypoint taking ownership, and this process can still inspect it after.
   chmodSync(dir, 0o777);
   TMP_DIRS.push(dir);
   return dir;
 }
 
-function getLogs(name: string): string {
-  try {
-    return run(`docker logs ${name} 2>&1`);
-  } catch {
-    return "(could not retrieve logs)";
-  }
-}
-
-async function pollHealth(port: number, name: string, timeoutMs = 30_000): Promise<void> {
-  const start = Date.now();
-  const url = `http://localhost:${port}/health`;
-  let lastError: unknown;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-      lastError = new Error(`Health check returned ${res.status}`);
-    } catch (err) {
-      lastError = err;
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  console.error("Container logs:\n" + getLogs(name));
-  throw new Error(`Health check timed out after ${timeoutMs}ms (last error: ${lastError})`);
-}
-
-async function waitForExit(name: string, timeoutMs = 30_000): Promise<void> {
+/** Waits for the container to stop and returns its exit code. */
+async function waitForExit(name: string, timeoutMs = 30_000): Promise<number> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const state = run(`docker inspect -f "{{.State.Running}}" ${name}`);
-    if (state === "false") return;
+    const state = run(`docker inspect -f "{{.State.Running}} {{.State.ExitCode}}" ${name}`);
+    const [running, code] = state.trim().split(/\s+/);
+    if (running === "false") return Number(code);
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(`Container ${name} was still running after ${timeoutMs}ms`);
+}
+
+/**
+ * Asserts a *deliberate* refusal to start: the entrypoint's own diagnostic, a
+ * non-zero exit, no server launched, and no Node crash. Waiting for the
+ * container to stop is not enough on its own — a server that starts and then
+ * dies on `ENOENT: mkdir` also stops, and that is the failure mode these
+ * scenarios exist to rule out.
+ */
+async function assertRefusedToStart(name: string, expected: string[]): Promise<void> {
+  const code = await waitForExit(name);
+  const logs = getLogs(name);
+  assert.notStrictEqual(code, 0, `Expected a non-zero exit code.\nLogs:\n${logs}`);
+  for (const line of expected) {
+    assert.ok(logs.includes(line), `Expected ${JSON.stringify(line)} in logs.\nLogs:\n${logs}`);
+  }
+  assert.ok(
+    !logs.includes("Server user:"),
+    `The server was started despite the unusable configuration.\nLogs:\n${logs}`,
+  );
+  assert.ok(
+    !logs.includes("ENOENT") && !/^\s+at .+\(/m.test(logs),
+    `Expected a clean refusal, not a Node crash.\nLogs:\n${logs}`,
+  );
+  console.log(`  Refused to start with a diagnostic (exit ${code}): OK`);
 }
 
 /**
@@ -125,12 +120,17 @@ function assertNonRoot(name: string, expectedUid = NODE_UID): void {
   console.log(`  Server runs as uid ${uid} (${owner}): OK`);
 }
 
-/** Numeric owner uid of each entry in a container directory. */
+/**
+ * Numeric owner uid of each entry in a container directory, dotfiles included:
+ * `seedRootOwnedVolume` plants a root-owned `.keep`, so a listing without -a
+ * would not notice a chown that stopped being recursive. The `.` and `..`
+ * entries that -a adds are dropped again.
+ */
 function dirOwnerUids(name: string, dir: string): number[] {
-  const listing = run(`docker exec ${name} ls -ln ${dir}`);
+  const listing = run(`docker exec ${name} ls -lan ${dir}`);
   return listing
     .split("\n")
-    .filter((l) => /^[-d]/.test(l))
+    .filter((l) => /^[-d]/.test(l) && !/\s\.\.?$/.test(l))
     .map((l) => Number(l.trim().split(/\s+/)[2]));
 }
 
@@ -140,23 +140,6 @@ function seedRootOwnedVolume(vol: string, mountPath: string): void {
     `docker run --rm --user 0:0 --entrypoint sh -v ${vol}:${mountPath} ${IMAGE} ` +
       `-c "touch ${mountPath}/.keep && chown -R root:root ${mountPath} && chmod 755 ${mountPath}"`,
   );
-}
-
-function makeSqsClient(port: number): SQSClient {
-  return new SQSClient({
-    endpoint: `http://localhost:${port}`,
-    region: "us-east-1",
-    credentials: { accessKeyId: "test", secretAccessKey: "test" },
-  });
-}
-
-function makeS3Client(port: number): S3Client {
-  return new S3Client({
-    endpoint: `http://localhost:${port}`,
-    region: "us-east-1",
-    credentials: { accessKeyId: "test", secretAccessKey: "test" },
-    forcePathStyle: true,
-  });
 }
 
 function banner(title: string): void {
@@ -420,10 +403,10 @@ async function testRunAsRootOptIn(): Promise<void> {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Scenario 7: unwritable write directory keeps privileges and says why
+// Scenario 7: a read-only write directory is refused, not worked around
 // ─────────────────────────────────────────────────────────────────────────────
-async function testUnwritableDirFallback(): Promise<void> {
-  banner("Scenario 7: read-only mount falls back to root with a diagnostic");
+async function testReadOnlyMountRefused(): Promise<void> {
+  banner("Scenario 7: read-only mount refuses to start with a diagnostic");
 
   const vol = volume("readonly");
   seedRootOwnedVolume(vol, "/s3data");
@@ -434,22 +417,176 @@ async function testUnwritableDirFallback(): Promise<void> {
       `-e FAUXQS_S3_STORAGE_DIR=/s3data -v ${vol}:/s3data:ro ${IMAGE}`,
   );
 
-  // chown cannot fix a read-only mount, so the entrypoint must not drop into a
-  // broken state — it explains the problem and stays root.
-  await waitForExit(name);
-  const logs = getLogs(name);
-  assert.ok(
-    logs.includes("WARNING: /s3data is not writable by 'node' and could not be chowned."),
-    `Expected the unwritable-directory warning in logs.\nLogs:\n${logs}`,
-  );
-  assert.ok(
-    logs.includes("Server user: root (fallback: /s3data not writable by 'node')"),
-    `Expected the root fallback message in logs.\nLogs:\n${logs}`,
-  );
-  console.log("  Warned about the unwritable mount and kept privileges: OK");
+  // Neither chown nor a fallback to root can fix a read-only mount, so the
+  // entrypoint has to say so instead of starting a server that would fail on
+  // its first write. The chown error itself must reach the logs too.
+  await assertRefusedToStart(name, [
+    "WARNING: /s3data could not be handed over to 'node'.",
+    "WARNING: chown said:",
+    "Read-only file system",
+    "ERROR: /s3data is writable by neither 'node' nor root",
+  ]);
 
   run(`docker rm -f ${name}`);
   console.log("\nScenario 7 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 8: --user with a mount it cannot write is caught at startup
+// ─────────────────────────────────────────────────────────────────────────────
+async function testStartedAsNonRootUnwritableMount(): Promise<void> {
+  banner("Scenario 8: --user + root-owned mount is refused at startup");
+
+  // The gap scenario 4 cannot cover: it uses an *empty* named volume, which
+  // inherits the image's ownership. A populated root-owned mount leaves the
+  // entrypoint no way to fix anything — it has no privileges to chown with —
+  // and SQLite would happily open the database read-only and then fail every
+  // write with "attempt to write a readonly database" behind a 200 /health.
+  const vol = volume("userunwritable");
+  seedRootOwnedVolume(vol, "/data");
+
+  const name = container("userunwritable");
+  run(
+    `docker run -d --name ${name} --user ${NODE_UID}:${NODE_UID} ` +
+      `-e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+
+  await assertRefusedToStart(name, [
+    `ERROR: /data is not writable by uid ${NODE_UID}.`,
+    "ERROR: The container was started as a non-root user",
+  ]);
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 8 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 9: an unusable FAUXQS_RUN_USER is rejected, never silently root
+// ─────────────────────────────────────────────────────────────────────────────
+async function testInvalidRunUserRejected(): Promise<void> {
+  banner("Scenario 9: unusable FAUXQS_RUN_USER is rejected");
+
+  // A typo used to be read as "the mount is not writable", which fell back to
+  // running the whole server as root — the exact opposite of what the variable
+  // was set to do — or killed the container with a raw su-exec error, depending
+  // on whether a write directory happened to be configured.
+  const vol = volume("baduser");
+  seedRootOwnedVolume(vol, "/data");
+
+  const withMount = container("baduser-mount");
+  run(
+    `docker run -d --name ${withMount} -e FAUXQS_RUN_USER=nosuchuser ` +
+      `-e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await assertRefusedToStart(withMount, [
+    "ERROR: FAUXQS_RUN_USER='nosuchuser' cannot be used to run the server.",
+  ]);
+  run(`docker rm -f ${withMount}`);
+
+  const withoutMount = container("baduser-plain");
+  run(`docker run -d --name ${withoutMount} -e FAUXQS_RUN_USER=nosuchuser ${IMAGE}`);
+  await assertRefusedToStart(withoutMount, [
+    "ERROR: FAUXQS_RUN_USER='nosuchuser' cannot be used to run the server.",
+  ]);
+  run(`docker rm -f ${withoutMount}`);
+
+  console.log("\nScenario 9 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 10: --cap-drop=ALL (Kubernetes' restricted policy) still starts
+// ─────────────────────────────────────────────────────────────────────────────
+async function testAllCapabilitiesDropped(): Promise<void> {
+  banner("Scenario 10: --user with --cap-drop=ALL");
+
+  // The restricted Pod Security Standard pairs runAsNonRoot with dropping every
+  // capability. dnsmasq's cap_net_bind_service+ep made execve itself fail with
+  // EPERM there, taking the whole container down with exit 126 before the
+  // server ever started. Wildcard DNS may legitimately be unavailable — the API
+  // must not be.
+  const name = container("nocaps");
+  const hostname = "fauxqs-nocaps";
+  run(
+    `docker run -d --name ${name} --hostname ${hostname} --user ${NODE_UID}:${NODE_UID} ` +
+      `--cap-drop=ALL -p ${HOST_PORT}:4566 ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, name);
+  assertNonRoot(name);
+
+  const s3 = makeS3Client(HOST_PORT);
+  await s3.send(new CreateBucketCommand({ Bucket: "nocaps-bucket" }));
+  await s3.send(new PutObjectCommand({ Bucket: "nocaps-bucket", Key: "k", Body: "no-caps" }));
+  const got = await s3.send(new GetObjectCommand({ Bucket: "nocaps-bucket", Key: "k" }));
+  assert.strictEqual(await got.Body!.transformToString(), "no-caps");
+  console.log("  API works with every capability dropped: OK");
+
+  // Whether port 53 is bindable depends on net.ipv4.ip_unprivileged_port_start,
+  // so accept either outcome — but an unavailable DNS has to be reported.
+  const logs = getLogs(name);
+  if (logs.includes("WARNING: dnsmasq could not bind port 53")) {
+    assert.ok(
+      logs.includes("WARNING: Add the NET_BIND_SERVICE capability"),
+      `Expected the capability hint alongside the DNS warning.\nLogs:\n${logs}`,
+    );
+    console.log("  Wildcard DNS unavailable, and said so: OK");
+  } else {
+    const dns = run(`docker exec ${name} nslookup b.s3.${hostname} 127.0.0.1`);
+    assert.ok(dns.includes(`b.s3.${hostname}`), `Wildcard DNS did not resolve:\n${dns}`);
+    console.log("  Wildcard DNS resolves without any capability: OK");
+  }
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 10 PASSED");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario 11: an already-writable mount keeps its ownership
+// ─────────────────────────────────────────────────────────────────────────────
+async function testWritableMountIsNotChowned(): Promise<void> {
+  banner("Scenario 11: an already-writable mount is left alone");
+
+  // `chown -R` on a bind mount rewrites the ownership of the host's files
+  // irreversibly, so it must only happen when it is actually needed. A mount
+  // that the unprivileged user can already write through its group must come
+  // out the other side owned by exactly who owned it going in.
+  const OTHER_UID = 1002;
+  const vol = volume("groupwritable");
+  run(
+    `docker run --rm --user 0:0 --entrypoint sh -v ${vol}:/data ${IMAGE} ` +
+      `-c "touch /data/pre.txt && chown -R ${OTHER_UID}:${NODE_UID} /data ` +
+      `&& chmod 775 /data && chmod 664 /data/pre.txt"`,
+  );
+
+  const name = container("groupwritable");
+  run(
+    `docker run -d --name ${name} -p ${HOST_PORT}:4566 ` +
+      `-e FAUXQS_PERSISTENCE=true -v ${vol}:/data ${IMAGE}`,
+  );
+  await pollHealth(HOST_PORT, name);
+  assertNonRoot(name);
+
+  const preOwner = run(`docker exec ${name} stat -c %u /data/pre.txt`).trim();
+  assert.strictEqual(
+    Number(preOwner),
+    OTHER_UID,
+    `The pre-existing file was chowned from ${OTHER_UID} to ${preOwner}`,
+  );
+  const dirOwner = run(`docker exec ${name} stat -c %u /data`).trim();
+  assert.strictEqual(
+    Number(dirOwner),
+    OTHER_UID,
+    `The mount itself was chowned from ${OTHER_UID} to ${dirOwner}`,
+  );
+  console.log(`  Ownership left at uid ${OTHER_UID}: OK`);
+
+  // ...and the server can still write, which is why no chown was needed.
+  const sqs = makeSqsClient(HOST_PORT);
+  const queue = await sqs.send(new CreateQueueCommand({ QueueName: "group-writable-q" }));
+  await sqs.send(new SendMessageCommand({ QueueUrl: queue.QueueUrl!, MessageBody: "grouped" }));
+  console.log("  Persistence works through group permissions: OK");
+
+  run(`docker rm -f ${name}`);
+  console.log("\nScenario 11 PASSED");
 }
 
 async function main(): Promise<void> {
@@ -464,7 +601,11 @@ async function main(): Promise<void> {
   await testStartedAsNonRoot();
   await testCustomRunUser();
   await testRunAsRootOptIn();
-  await testUnwritableDirFallback();
+  await testReadOnlyMountRefused();
+  await testStartedAsNonRootUnwritableMount();
+  await testInvalidRunUserRejected();
+  await testAllCapabilitiesDropped();
+  await testWritableMountIsNotChowned();
 
   console.log("\n══════════════════════════════════════");
   console.log("  All non-root acceptance tests passed!");

--- a/docker-acceptance/docker-persistence-acceptance.ts
+++ b/docker-acceptance/docker-persistence-acceptance.ts
@@ -1,21 +1,26 @@
 import * as assert from "node:assert";
-import { execSync } from "node:child_process";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  SQSClient,
   CreateQueueCommand,
   SendMessageCommand,
   ReceiveMessageCommand,
 } from "@aws-sdk/client-sqs";
 import {
-  S3Client,
   CreateBucketCommand,
   PutObjectCommand,
   GetObjectCommand,
   ListBucketsCommand,
 } from "@aws-sdk/client-s3";
+import {
+  getLogs,
+  makeS3Client,
+  makeSqsClient,
+  pollHealth,
+  run,
+  runWithEnv,
+} from "./dockerTestUtils.ts";
 
 const IMAGE = process.env.FAUXQS_TEST_IMAGE ?? "fauxqs-persistence-test";
 const VOLUME_NAME = `fauxqs-persist-test-${Date.now()}`;
@@ -27,61 +32,6 @@ const DISABLED_CONTAINER = `fauxqs-disabled-${Date.now()}`;
 const COMPOSE_PROJECT = `fauxqs-compose-persist-${Date.now()}`;
 const COMPOSE_FILE = "docker-acceptance/docker-compose.persistence-disabled.yml";
 const HOST_PORT = 14567;
-
-function run(cmd: string): string {
-  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-}
-
-function runWithEnv(cmd: string, env: Record<string, string>): string {
-  return execSync(cmd, {
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    env: { ...process.env, ...env },
-  }).trim();
-}
-
-function getLogs(containerName: string): string {
-  try {
-    return run(`docker logs ${containerName} 2>&1`);
-  } catch {
-    return "(could not retrieve logs)";
-  }
-}
-
-async function pollHealth(port: number, containerName: string, timeoutMs = 30_000): Promise<void> {
-  const start = Date.now();
-  const url = `http://localhost:${port}/health`;
-  let lastError: unknown;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-      lastError = new Error(`Health check returned ${res.status}`);
-    } catch (err) {
-      lastError = err;
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  console.error("Container logs:\n" + getLogs(containerName));
-  throw new Error(`Health check timed out after ${timeoutMs}ms (last error: ${lastError})`);
-}
-
-function makeSqsClient(port: number): SQSClient {
-  return new SQSClient({
-    endpoint: `http://localhost:${port}`,
-    region: "us-east-1",
-    credentials: { accessKeyId: "test", secretAccessKey: "test" },
-  });
-}
-
-function makeS3Client(port: number): S3Client {
-  return new S3Client({
-    endpoint: `http://localhost:${port}`,
-    region: "us-east-1",
-    credentials: { accessKeyId: "test", secretAccessKey: "test" },
-    forcePathStyle: true,
-  });
-}
 
 async function testWithVolume(): Promise<void> {
   console.log("\n══════════════════════════════════════");

--- a/docker-acceptance/docker-s3-storage-acceptance.ts
+++ b/docker-acceptance/docker-s3-storage-acceptance.ts
@@ -1,7 +1,5 @@
 import * as assert from "node:assert";
-import { execSync } from "node:child_process";
 import {
-  S3Client,
   CreateBucketCommand,
   PutObjectCommand,
   GetObjectCommand,
@@ -9,11 +7,18 @@ import {
   ListObjectsV2Command,
 } from "@aws-sdk/client-s3";
 import {
-  SQSClient,
   CreateQueueCommand,
   SendMessageCommand,
   ReceiveMessageCommand,
 } from "@aws-sdk/client-sqs";
+import {
+  getLogs,
+  makeS3Client,
+  makeSqsClient,
+  pollHealth,
+  run,
+  runWithEnv,
+} from "./dockerTestUtils.ts";
 
 const IMAGE = process.env.FAUXQS_TEST_IMAGE ?? "fauxqs-s3-storage-test";
 const VOLUME_NAME = `fauxqs-s3-test-${Date.now()}`;
@@ -25,61 +30,6 @@ const MIXED_CONTAINER = `fauxqs-mixed-${Date.now()}`;
 const COMPOSE_PROJECT = `fauxqs-compose-s3-${Date.now()}`;
 const COMPOSE_FILE = "docker-acceptance/docker-compose.s3-storage.yml";
 const HOST_PORT = 14568;
-
-function run(cmd: string): string {
-  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-}
-
-function runWithEnv(cmd: string, env: Record<string, string>): string {
-  return execSync(cmd, {
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    env: { ...process.env, ...env },
-  }).trim();
-}
-
-function getLogs(containerName: string): string {
-  try {
-    return run(`docker logs ${containerName} 2>&1`);
-  } catch {
-    return "(could not retrieve logs)";
-  }
-}
-
-async function pollHealth(port: number, containerName: string, timeoutMs = 30_000): Promise<void> {
-  const start = Date.now();
-  const url = `http://localhost:${port}/health`;
-  let lastError: unknown;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-      lastError = new Error(`Health check returned ${res.status}`);
-    } catch (err) {
-      lastError = err;
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  console.error("Container logs:\n" + getLogs(containerName));
-  throw new Error(`Health check timed out after ${timeoutMs}ms (last error: ${lastError})`);
-}
-
-function makeS3Client(port: number): S3Client {
-  return new S3Client({
-    endpoint: `http://localhost:${port}`,
-    region: "us-east-1",
-    credentials: { accessKeyId: "test", secretAccessKey: "test" },
-    forcePathStyle: true,
-  });
-}
-
-function makeSqsClient(port: number): SQSClient {
-  return new SQSClient({
-    endpoint: `http://localhost:${port}`,
-    region: "us-east-1",
-    credentials: { accessKeyId: "test", secretAccessKey: "test" },
-  });
-}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Scenario 1: S3 file storage with volume — state survives restart

--- a/docker-acceptance/dockerTestUtils.ts
+++ b/docker-acceptance/dockerTestUtils.ts
@@ -1,0 +1,68 @@
+import { execSync } from "node:child_process";
+import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
+
+/**
+ * Helpers shared by the Docker acceptance suites. They all drive real
+ * containers, so keep them dependency-free and side-effect-free at import time.
+ */
+
+export function run(cmd: string): string {
+  return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+}
+
+export function runWithEnv(cmd: string, env: Record<string, string>): string {
+  return execSync(cmd, {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  }).trim();
+}
+
+export function getLogs(containerName: string): string {
+  try {
+    return run(`docker logs ${containerName} 2>&1`);
+  } catch {
+    return "(could not retrieve logs)";
+  }
+}
+
+/** Waits for /health to answer 200, dumping the container's logs on timeout. */
+export async function pollHealth(
+  port: number,
+  containerName: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const start = Date.now();
+  const url = `http://localhost:${port}/health`;
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+      lastError = new Error(`Health check returned ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  console.error("Container logs:\n" + getLogs(containerName));
+  throw new Error(`Health check timed out after ${timeoutMs}ms (last error: ${lastError})`);
+}
+
+export function makeSqsClient(port: number): SQSClient {
+  return new SQSClient({
+    endpoint: `http://localhost:${port}`,
+    region: "us-east-1",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  });
+}
+
+export function makeS3Client(port: number): S3Client {
+  return new S3Client({
+    endpoint: `http://localhost:${port}`,
+    region: "us-east-1",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    forcePathStyle: true,
+  });
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,12 +5,56 @@ set -e
 # Accepts a name, a uid, or uid:gid — anything su-exec and chown understand.
 RUN_USER=${FAUXQS_RUN_USER:-node}
 
+# `docker run --user` and Kubernetes runAsUser start us unprivileged: there is
+# nothing to chown and nobody to drop to, so most of this script is skipped.
+if [ "$(id -u)" = "0" ]; then
+  STARTED_AS_ROOT=true
+else
+  STARTED_AS_ROOT=false
+fi
+
+# Catch a bad FAUXQS_RUN_USER here rather than several steps later, where a
+# failing chown and a failing su-exec look exactly like an unwritable mount.
+if [ "$STARTED_AS_ROOT" = true ] && [ "$FAUXQS_RUN_AS_ROOT" != "true" ]; then
+  if ! su-exec "$RUN_USER" true 2>/dev/null; then
+    echo "ERROR: FAUXQS_RUN_USER='$RUN_USER' cannot be used to run the server." >&2
+    echo "ERROR: Use a user that exists in the image ('node'), or a numeric uid" >&2
+    echo "ERROR: or uid:gid — those do not need an /etc/passwd entry." >&2
+    exit 1
+  fi
+fi
+
 CONTAINER_IP=$(hostname -i | awk '{print $1}')
 DNS_NAME=${FAUXQS_DNS_NAME:-$(hostname)}
 UPSTREAM=${FAUXQS_DNS_UPSTREAM:-8.8.8.8}
 
-echo "Starting dnsmasq: *.${DNS_NAME} -> ${CONTAINER_IP} (upstream: ${UPSTREAM})"
-dnsmasq --address=/${DNS_NAME}/${CONTAINER_IP} --server=${UPSTREAM} --no-resolv
+# Wildcard DNS is a convenience: the API works without it, so a container that
+# cannot bind port 53 should say so and carry on rather than exit.
+#
+# /usr/sbin/dnsmasq carries cap_net_bind_service+ep so it can bind port 53 when
+# the container runs unprivileged. The effective bit is what actually delivers
+# the capability, but it also makes execve fail with EPERM whenever
+# NET_BIND_SERVICE is missing from the bounding set (--cap-drop=ALL, Kubernetes'
+# restricted policy). The uncapped copy covers that case: it cannot ask for the
+# capability, but it does not need it wherever port 53 is unprivileged, which is
+# the default in Docker.
+start_dnsmasq() {
+  echo "Starting dnsmasq: *.${DNS_NAME} -> ${CONTAINER_IP} (upstream: ${UPSTREAM})"
+  dnsmasq_error=""
+  for binary in /usr/sbin/dnsmasq /usr/sbin/dnsmasq-nocap; do
+    if dnsmasq_error=$("$binary" --address=/"${DNS_NAME}"/"${CONTAINER_IP}" \
+      --server="${UPSTREAM}" --no-resolv 2>&1); then
+      return 0
+    fi
+  done
+  echo "WARNING: dnsmasq could not bind port 53: ${dnsmasq_error:-permission denied}"
+  echo "WARNING: Wildcard DNS is unavailable, so *.${DNS_NAME} will not resolve"
+  echo "WARNING: inside the container and virtual-host-style S3 addressing needs"
+  echo "WARNING: forcePathStyle on the client. The API is otherwise unaffected."
+  echo "WARNING: Add the NET_BIND_SERVICE capability to enable wildcard DNS."
+  return 0
+}
+start_dnsmasq
 
 # Disable persistence if /data is not a mounted volume (avoids writing to ephemeral container storage)
 if [ -n "$FAUXQS_DATA_DIR" ] && ! mountpoint -q "$FAUXQS_DATA_DIR" 2>/dev/null; then
@@ -47,51 +91,131 @@ else
   echo "Tenant management: OFF"
 fi
 
-# Directories the server actually writes to — these must be writable by RUN_USER.
-# Mirrors src/server.ts: dataDir is only used when FAUXQS_PERSISTENCE=true.
-# Collected as positional parameters so that paths containing spaces survive.
-set --
-if [ "$FAUXQS_PERSISTENCE" = "true" ] && [ -n "$FAUXQS_DATA_DIR" ]; then
-  set -- "$@" "$FAUXQS_DATA_DIR"
-fi
-if [ -n "$FAUXQS_S3_STORAGE_DIR" ]; then
-  set -- "$@" "$FAUXQS_S3_STORAGE_DIR"
-fi
+# Is the directory in $FAUXQS_PROBE_DIR writable, including what is already in
+# it? Two things make this less obvious than `test -w`:
+#
+#   * for root, `test -w` reports success on a read-only mount even though every
+#     write then fails with EROFS, so the directory is tested by creating a file;
+#   * a root-owned fauxqs.db inside a world-writable /data passes a check on the
+#     directory alone and then fails every write at runtime, so the entries are
+#     tested too. Only the top level — anything deeper is covered by the
+#     recursive chown, and `test -w` is accurate for the unprivileged user.
+#
+# The path is passed through the environment so that the inner shell never
+# parses it — quoting it into `sh -c` would re-expand $, quotes and spaces.
+PROBE='
+  probe=$FAUXQS_PROBE_DIR/.fauxqs-write-probe
+  : > "$probe" 2>/dev/null || exit 1
+  rm -f "$probe"
+  for entry in "$FAUXQS_PROBE_DIR"/* "$FAUXQS_PROBE_DIR"/.[!.]*; do
+    [ -e "$entry" ] || continue
+    [ -w "$entry" ] || exit 1
+  done
+'
 
+writable_by_run_user() {
+  FAUXQS_PROBE_DIR=$1 su-exec "$RUN_USER" sh -c "$PROBE" 2>/dev/null
+}
+
+writable_by_me() {
+  FAUXQS_PROBE_DIR=$1 sh -c "$PROBE" 2>/dev/null
+}
+
+# Set when the server has to stay root to be able to write to a directory that
+# could not be handed over to RUN_USER.
+ROOT_FALLBACK_REASON=""
+
+# Makes $1 writable by the user the server will run as, or fails the container.
+# Never returns with the directory in a state the server cannot use.
+check_write_dir() {
+  dir=$1
+
+  # Started unprivileged: no chown, and no user to switch to. All we can do is
+  # report it, which still beats a healthy-looking container that answers every
+  # write with "attempt to write a readonly database".
+  if [ "$STARTED_AS_ROOT" = false ]; then
+    writable_by_me "$dir" && return 0
+    echo "ERROR: $dir is not writable by uid $(id -u)." >&2
+    echo "ERROR: The container was started as a non-root user, so it cannot take" >&2
+    echo "ERROR: ownership of the mount itself. Either chown the mount to that uid" >&2
+    echo "ERROR: on the host, or start the container as root and let the entrypoint" >&2
+    echo "ERROR: hand it over." >&2
+    exit 1
+  fi
+
+  if [ "$FAUXQS_RUN_AS_ROOT" = "true" ]; then
+    writable_by_me "$dir" && return 0
+    echo "ERROR: $dir is not writable even as root — most likely a read-only mount." >&2
+    echo "ERROR: Mount it read-write, or unset the variable that points at it." >&2
+    exit 1
+  fi
+
+  # Already usable: leave the mount's ownership exactly as it is. This is the
+  # common case on every restart and for host directories that are already
+  # prepared, and it keeps `chown -R` off host files that do not need it.
+  writable_by_run_user "$dir" && return 0
+
+  # Bind-mounted host directories are typically root-owned, so hand this one
+  # over — only now that the probe has shown it is actually necessary.
+  chown_error=$(chown -R "$RUN_USER" "$dir" 2>&1) || true
+  writable_by_run_user "$dir" && return 0
+
+  echo "WARNING: $dir could not be handed over to '$RUN_USER'."
+  if [ -n "$chown_error" ]; then
+    echo "WARNING: chown said: $chown_error"
+  fi
+
+  # Some remote filesystems ignore chown while root can still write. Staying
+  # root keeps those setups working, and unlike a blind fallback it is backed by
+  # a check: root demonstrably can write here.
+  if writable_by_me "$dir"; then
+    echo "WARNING: Keeping the server as root, which can write to $dir."
+    echo "WARNING: Set FAUXQS_RUN_USER to a user that owns it to drop privileges."
+    ROOT_FALLBACK_REASON="$dir not writable by '$RUN_USER'"
+    return 0
+  fi
+
+  echo "ERROR: $dir is writable by neither '$RUN_USER' nor root — most likely a" >&2
+  echo "ERROR: read-only mount. Root could not write it either, so falling back to" >&2
+  echo "ERROR: root would only trade one failure for another: refusing to start." >&2
+  echo "ERROR: Mount $dir read-write, or unset the variable that points at it." >&2
+  exit 1
+}
+
+# Directories the server actually writes to. Collected as this function's own
+# positional parameters, which shadow the script's: paths containing spaces
+# survive, and the container's CMD arguments in $@ are left untouched.
+# Mirrors src/server.ts: dataDir is only used when FAUXQS_PERSISTENCE=true.
+preflight_write_dirs() {
+  set --
+  if [ "$FAUXQS_PERSISTENCE" = "true" ] && [ -n "$FAUXQS_DATA_DIR" ]; then
+    set -- "$@" "$FAUXQS_DATA_DIR"
+  fi
+  if [ -n "$FAUXQS_S3_STORAGE_DIR" ]; then
+    set -- "$@" "$FAUXQS_S3_STORAGE_DIR"
+  fi
+  for dir in "$@"; do
+    check_write_dir "$dir"
+  done
+}
+
+preflight_write_dirs
+
+# The one place the server is launched. $1 describes the user it ends up running
+# as; anything after it is a launcher prefix the server command is appended to.
 start_server() {
   echo "Server user: $1"
   shift
-  exec "$@"
+  exec "$@" tini -- node dist/server.js
 }
 
-# Already unprivileged (docker run --user, Kubernetes runAsUser): nothing to drop.
-# dnsmasq carries cap_net_bind_service as a file capability so port 53 still works.
-if [ "$(id -u)" != "0" ]; then
-  start_server "$(id -un 2>/dev/null || id -u) (container started as non-root)" \
-    tini -- node dist/server.js
-fi
-
-# Escape hatch for setups where the server genuinely needs root.
 if [ "$FAUXQS_RUN_AS_ROOT" = "true" ]; then
-  start_server "root (FAUXQS_RUN_AS_ROOT=true)" tini -- node dist/server.js
+  # Escape hatch for setups where the server genuinely needs root.
+  start_server "root (FAUXQS_RUN_AS_ROOT=true)"
+elif [ "$STARTED_AS_ROOT" = false ]; then
+  start_server "$(id -un 2>/dev/null || id -u) (container started as non-root)"
+elif [ -n "$ROOT_FALLBACK_REASON" ]; then
+  start_server "root (fallback: $ROOT_FALLBACK_REASON)"
+else
+  start_server "$RUN_USER" su-exec "$RUN_USER"
 fi
-
-# Hand the mounted directories over to RUN_USER. Bind-mounted host directories
-# are typically root-owned, so this is what keeps `-v ./volume:/data` working.
-for dir in "$@"; do
-  chown -R "$RUN_USER" "$dir" 2>/dev/null || true
-done
-
-# If a directory still isn't writable (read-only mount, remote filesystem that
-# ignores chown), keep running as root rather than crash-looping on startup.
-for dir in "$@"; do
-  if ! su-exec "$RUN_USER" sh -c "[ -w \"$dir\" ]" 2>/dev/null; then
-    echo "WARNING: $dir is not writable by '$RUN_USER' and could not be chowned."
-    echo "WARNING: Falling back to running the server as root. Fix the ownership on"
-    echo "WARNING: the host, or set FAUXQS_RUN_USER to a user that can write to it."
-    start_server "root (fallback: $dir not writable by '$RUN_USER')" \
-      tini -- node dist/server.js
-  fi
-done
-
-start_server "$RUN_USER" su-exec "$RUN_USER" tini -- node dist/server.js

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# User the server process runs as once the privileged setup below is done.
+# Accepts a name, a uid, or uid:gid — anything su-exec and chown understand.
+RUN_USER=${FAUXQS_RUN_USER:-node}
+
 CONTAINER_IP=$(hostname -i | awk '{print $1}')
 DNS_NAME=${FAUXQS_DNS_NAME:-$(hostname)}
 UPSTREAM=${FAUXQS_DNS_UPSTREAM:-8.8.8.8}
@@ -43,4 +47,51 @@ else
   echo "Tenant management: OFF"
 fi
 
-exec tini -- node dist/server.js
+# Directories the server actually writes to — these must be writable by RUN_USER.
+# Mirrors src/server.ts: dataDir is only used when FAUXQS_PERSISTENCE=true.
+# Collected as positional parameters so that paths containing spaces survive.
+set --
+if [ "$FAUXQS_PERSISTENCE" = "true" ] && [ -n "$FAUXQS_DATA_DIR" ]; then
+  set -- "$@" "$FAUXQS_DATA_DIR"
+fi
+if [ -n "$FAUXQS_S3_STORAGE_DIR" ]; then
+  set -- "$@" "$FAUXQS_S3_STORAGE_DIR"
+fi
+
+start_server() {
+  echo "Server user: $1"
+  shift
+  exec "$@"
+}
+
+# Already unprivileged (docker run --user, Kubernetes runAsUser): nothing to drop.
+# dnsmasq carries cap_net_bind_service as a file capability so port 53 still works.
+if [ "$(id -u)" != "0" ]; then
+  start_server "$(id -un 2>/dev/null || id -u) (container started as non-root)" \
+    tini -- node dist/server.js
+fi
+
+# Escape hatch for setups where the server genuinely needs root.
+if [ "$FAUXQS_RUN_AS_ROOT" = "true" ]; then
+  start_server "root (FAUXQS_RUN_AS_ROOT=true)" tini -- node dist/server.js
+fi
+
+# Hand the mounted directories over to RUN_USER. Bind-mounted host directories
+# are typically root-owned, so this is what keeps `-v ./volume:/data` working.
+for dir in "$@"; do
+  chown -R "$RUN_USER" "$dir" 2>/dev/null || true
+done
+
+# If a directory still isn't writable (read-only mount, remote filesystem that
+# ignores chown), keep running as root rather than crash-looping on startup.
+for dir in "$@"; do
+  if ! su-exec "$RUN_USER" sh -c "[ -w \"$dir\" ]" 2>/dev/null; then
+    echo "WARNING: $dir is not writable by '$RUN_USER' and could not be chowned."
+    echo "WARNING: Falling back to running the server as root. Fix the ownership on"
+    echo "WARNING: the host, or set FAUXQS_RUN_USER to a user that can write to it."
+    start_server "root (fallback: $dir not writable by '$RUN_USER')" \
+      tini -- node dist/server.js
+  fi
+done
+
+start_server "$RUN_USER" su-exec "$RUN_USER" tini -- node dist/server.js

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:docker:compose": "node docker-acceptance/docker-compose-acceptance.ts",
     "test:docker:persistence": "node docker-acceptance/docker-persistence-acceptance.ts",
     "test:docker:s3-storage": "node docker-acceptance/docker-s3-storage-acceptance.ts",
+    "test:docker:nonroot": "node docker-acceptance/docker-nonroot-acceptance.ts",
     "bench": "node bench/getQueueByArn.bench.ts && node bench/createMessage.bench.ts && node bench/snsPublish.bench.ts",
     "lint": "oxlint && oxfmt src && tsc --noEmit",
     "lint:fix": "oxlint --fix && oxfmt --write src",


### PR DESCRIPTION
The image has no runtime `USER`, so the server runs as root (Trivy DS-0002). This fixes it in a way that doesn't break the mount layouts the docs recommend.

## Why not just `USER node`

A bind-mounted host directory is root-owned — `docker run -v ./volume:/data` creates it as `root:root` — and an unprivileged process can't open a SQLite database in it. I reproduced the crash-loop:

```
Error: unable to open database file
    at new PersistenceManager (file:///app/dist/persistence.js:119:19)
  code: 'ERR_SQLITE_ERROR', errcode: 14
```

Every consumer following the persistence docs would break on upgrade.

## What this does instead

The entrypoint keeps root only for the work that needs it — binding dnsmasq to port 53 and handing the mounted directories to the run user — then drops to `node` (uid 1000) with `su-exec` before starting the server. PID 1 is still tini, now running unprivileged.

- **`setcap cap_net_bind_service+ep` on dnsmasq**, so the image also works with no root phase at all (`docker run --user 1000:1000`, k8s `runAsUser`). Wildcard DNS keeps working in that mode.
- **`/data` pre-created as `node:node`**, so an empty named volume inherits that ownership from the image — persistence works under `--user` without any host-side preparation.
- **`FAUXQS_RUN_USER`** — name, uid, or `uid:gid` — for host directories that must keep a specific owner.
- **`FAUXQS_RUN_AS_ROOT=true`** — escape hatch back to the old behaviour.
- **Unwritable directory**: logs which directory is at fault. When `chown` is merely ineffective (remote filesystems that ignore it) but root can still write, the server stays root and says so. When nothing can write it — a read-only mount — it refuses to start, because root cannot write it either and starting anyway would fail on the first write.
- **Already-writable directory**: left untouched. `chown -R` only runs where a probe shows it is needed, so host file ownership is not rewritten and restarts do not walk every stored object.
- **Unusable `FAUXQS_RUN_USER`**: rejected at startup instead of being mistaken for an unwritable mount and silently running the server as root.
- **`--cap-drop=ALL`** (Kubernetes' `restricted` policy): starts normally. `cap_net_bind_service+ep` on dnsmasq makes `execve` fail with EPERM when NET_BIND_SERVICE is missing from the bounding set, so the image keeps an uncapped copy of dnsmasq to fall back to; at worst wildcard DNS is unavailable and the log says so.

Only the directories the server actually writes to are chowned/checked, mirroring `src/server.ts` (`dataDir` only counts when `FAUXQS_PERSISTENCE=true`).

No `USER` directive, deliberately — the entrypoint needs the root phase. There's a comment in the Dockerfile saying so, and Trivy DS-0002 will still fire on it; consumers who want zero root use `--user`.

## Coverage

New suite `docker-acceptance/docker-nonroot-acceptance.ts` (`pnpm test:docker:nonroot`, wired into the acceptance workflow), 11 scenarios:

| # | Scenario | Asserts |
| --- | --- | --- |
| 1 | Default run | server uid is 1000, wildcard DNS resolves, S3 put/get works |
| 2 | Root-owned `/data` + persistence | healthy, non-root, `/data` contents owned by 1000, state survives restart |
| 3 | Host bind mount + read-only mounted `init.json` | non-root, init config applied, SQLite lands on the host directory |
| 4 | `--user 1000:1000` | non-root startup path, dnsmasq binds :53 without root, persistence survives restart |
| 5 | `FAUXQS_RUN_USER=1001` on a root-owned mount | server uid is 1001, `/data` handed to 1001, writes succeed |
| 6 | `FAUXQS_RUN_AS_ROOT=true` | server runs as root on request |
| 7 | Read-only write directory | refuses to start: warning names the directory, the `chown` error is surfaced, non-zero exit, no server launched, no Node stack trace |
| 8 | `--user 1000:1000` + root-owned populated mount | refuses to start rather than serving a healthy `/health` while every write fails |
| 9 | Unusable `FAUXQS_RUN_USER` | refuses to start, with and without a write directory configured |
| 10 | `--user 1000:1000 --cap-drop=ALL` | healthy, non-root, S3 put/get works; wildcard DNS either resolves or is reported as unavailable |
| 11 | Mount already writable via group | ownership left at its original uid (no `chown`), persistence still works |

The process user is read from `/proc/1/status` plus `ps`, so it can't pass by accident.

**Mutation-checked** — the suite was run against two deliberately broken images to confirm it fails:

- entrypoint that never drops privileges → scenario 1 fails (`Expected "Server user: node" in logs`)
- naive `USER node` → scenario 2 fails with the `ERR_SQLITE_ERROR` above in the dumped container logs

## Verification

- `pnpm test` — 935 passed
- `pnpm lint` — clean
- `pnpm test:docker`, `test:docker:compose`, `test:docker:persistence` (6 scenarios), `test:docker:s3-storage` (4 scenarios) — all pass against the new image
- `pnpm test:docker:nonroot` — 7/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker containers now run as an unprivileged user by default, with options to select the runtime user or enable root execution.
  * Improved handling of persistent data, bind mounts, DNS, S3, and SQS in non-root containers.
  * Startup now validates permissions and reports unusable mounts early.
  * Added guidance for volume ownership, container configuration, and required DNS capabilities.

* **Tests**
  * Added comprehensive Docker acceptance coverage for non-root execution, persistence, permissions, and capability-restricted environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
